### PR TITLE
Add determinant functionality

### DIFF
--- a/src/abstractMatrix.js
+++ b/src/abstractMatrix.js
@@ -2,6 +2,7 @@
 
 module.exports = abstractMatrix;
 
+var LuDecomposition = require('./dc/lu');
 var arrayUtils = require('ml-array-utils');
 var util = require('./util');
 var MatrixTransposeView = require('./views/transpose');
@@ -1511,7 +1512,6 @@ function abstractMatrix(superCtor) {
         * 
         * @return {number}
         */
-
         det(){
             if(this.isSquare()){
                 if(this.columns === 2){
@@ -1539,9 +1539,8 @@ function abstractMatrix(superCtor) {
                     return a * subMatrix0.det()  - b * subMatrix1.det() + c * subMatrix2.det();
 
                 }else{
-                    // general purpose determinant
-                    
-                    throw Error('Not implemented yet');
+                    // general purpose determinant using the LU decomposition
+                    return new LuDecomposition(this, {skipCheck:true}).determinant;
                 }
 
             }else{

--- a/src/abstractMatrix.js
+++ b/src/abstractMatrix.js
@@ -1509,41 +1509,36 @@ function abstractMatrix(superCtor) {
         * Calculates and returns the determinant of a matrix as a Number
         * @example
         *   new Matrix([[1,2,3], [4,5,6]]).det()
-        * 
         * @return {number}
         */
-        det(){
-            if(this.isSquare()){
-                if(this.columns === 2){
-                    // 2 x 2 matrix 
-                    var a,b,c,d;
+        det() {
+            if (this.isSquare()) {
+                var a, b, c, d;
+                if (this.columns === 2) {
+                    // 2 x 2 matrix
                     a = this.get(0, 0);
                     b = this.get(0, 1);
                     c = this.get(1, 0);
                     d = this.get(1, 1);
 
-                    return a * d - ( b * c);
-
-                }else if(this.columns === 3){
+                    return a * d - (b * c);
+                } else if (this.columns === 3) {
                     // 3 x 3 matrix
                     var subMatrix0, subMatrix1, subMatrix2;
-                    var a, b, c;
-                    
                     subMatrix0 = this.selection([1, 2], [1, 2]);
                     subMatrix1 = this.selection([1, 2], [0, 2]);
                     subMatrix2 = this.selection([1, 2], [0, 1]);
                     a = this.get(0, 0);
                     b = this.get(0, 1);
                     c = this.get(0, 2);
-                    
-                    return a * subMatrix0.det()  - b * subMatrix1.det() + c * subMatrix2.det();
 
-                }else{
+                    return a * subMatrix0.det() - b * subMatrix1.det() + c * subMatrix2.det();
+                } else {
                     // general purpose determinant using the LU decomposition
-                    return new LuDecomposition(this, {skipCheck:true}).determinant;
+                    return new LuDecomposition(this, {skipCheck: true}).determinant;
                 }
 
-            }else{
+            } else {
                 throw Error('Determinant can only be calculated for a square matrix.');
             }
         }

--- a/src/abstractMatrix.js
+++ b/src/abstractMatrix.js
@@ -1502,6 +1502,52 @@ function abstractMatrix(superCtor) {
         selectionView(rowIndices, columnIndices) {
             return new MatrixSelectionView(this, rowIndices, columnIndices);
         }
+
+
+        /**
+        * Calculates and returns the determinant of a matrix as a Number
+        * @example
+        *   new Matrix([[1,2,3], [4,5,6]]).det()
+        * 
+        * @return {number}
+        */
+
+        det(){
+            if(this.isSquare()){
+                if(this.columns === 2){
+                    // 2 x 2 matrix 
+                    var a,b,c,d;
+                    a = this.get(0, 0);
+                    b = this.get(0, 1);
+                    c = this.get(1, 0);
+                    d = this.get(1, 1);
+
+                    return a * d - ( b * c);
+
+                }else if(this.columns === 3){
+                    // 3 x 3 matrix
+                    var subMatrix0, subMatrix1, subMatrix2;
+                    var a, b, c;
+                    
+                    subMatrix0 = this.selection([1, 2], [1, 2]);
+                    subMatrix1 = this.selection([1, 2], [0, 2]);
+                    subMatrix2 = this.selection([1, 2], [0, 1]);
+                    a = this.get(0, 0);
+                    b = this.get(0, 1);
+                    c = this.get(0, 2);
+                    
+                    return a * subMatrix0.det()  - b * subMatrix1.det() + c * subMatrix2.det();
+
+                }else{
+                    // general purpose determinant
+                    
+                    throw Error('Not implemented yet');
+                }
+
+            }else{
+                throw Error('Determinant can only be calculated for a square matrix.');
+            }
+        }
     }
 
     Matrix.prototype.klass = 'Matrix';

--- a/src/dc/lu.js
+++ b/src/dc/lu.js
@@ -10,7 +10,7 @@ function LuDecomposition(matrix, options) {
 
     options = options || {};
 
-    if(!options.skipCheck){
+    if (!options.skipCheck) {
         matrix = Matrix.checkMatrix(matrix);
     }
 

--- a/src/dc/lu.js
+++ b/src/dc/lu.js
@@ -3,11 +3,16 @@
 var Matrix = require('../matrix');
 
 // https://github.com/lutzroeder/Mapack/blob/master/Source/LuDecomposition.cs
-function LuDecomposition(matrix) {
+function LuDecomposition(matrix, options) {
     if (!(this instanceof LuDecomposition)) {
         return new LuDecomposition(matrix);
     }
-    matrix = Matrix.checkMatrix(matrix);
+
+    options = options || {};
+
+    if(!options.skipCheck){
+        matrix = Matrix.checkMatrix(matrix);
+    }
 
     var lu = matrix.clone(),
         rows = lu.rows,

--- a/test/matrix/utility.js
+++ b/test/matrix/utility.js
@@ -85,11 +85,11 @@ describe('utility methods', function () {
         transpose[2][1].should.equal(matrix[1][2]);
     });
 
-    it('determinant', function(){
+    it('determinant', function () {
         var determinant = matrix.det();
         determinant.should.equal(-18);
-        var subMatrix = matrix.selection([1,2], [1,2]);
-        determinant = subMatrix.det()
+        var subMatrix = matrix.selection([1, 2], [1, 2]);
+        determinant = subMatrix.det();
         determinant.should.equal(-9);
     });
     it('transpose rectangular', function () {

--- a/test/matrix/utility.js
+++ b/test/matrix/utility.js
@@ -85,6 +85,13 @@ describe('utility methods', function () {
         transpose[2][1].should.equal(matrix[1][2]);
     });
 
+    it('determinant', function(){
+        var determinant = matrix.det();
+        determinant.should.equal(-18);
+        var subMatrix = matrix.selection([1,2], [1,2]);
+        determinant = subMatrix.det()
+        determinant.should.equal(-9);
+    });
     it('transpose rectangular', function () {
         var matrix = new Matrix([[0, 1, 2], [3, 4, 5]]);
         var transpose = matrix.transpose();


### PR DESCRIPTION
Adds functionality to compute the determinant based on the LU decomposition for `Matrix` of size >3 as discussed in #45.

I had to add an "option" in `lu.js` to skip the check. I think it doesn't work with the check is because of some kind of circular referencing going on. The only side effect of calculating the determinant this way is that we have an "approximate" determinant. If circular referencing weren't an issue we could do `LU.upperTriangularMatrix` and `LU.lowerTriangularMatrix` and compute the two determinant and multiply them together to get an exact solution.

