### PR TITLE
Support Empty Matrices

### DIFF
--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -305,7 +305,7 @@ export abstract class AbstractMatrix {
   isSquare(): boolean;
 
   /**
-   * Returns whether the matrix has one or more 0 dimensions
+   * Returns whether the matrix has one or more 0 dimensions.
    */
   isEmpty(): boolean;
 

--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -305,6 +305,11 @@ export abstract class AbstractMatrix {
   isSquare(): boolean;
 
   /**
+   * Returns whether the matrix has one or more 0 dimensions
+   */
+  isEmpty(): boolean;
+
+  /**
    * Returns whether the matrix is square and has the same values on both sides of the diagonal.
    */
   isSymmetric(): boolean;

--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -305,7 +305,7 @@ export abstract class AbstractMatrix {
   isSquare(): boolean;
 
   /**
-   * Returns whether the matrix has one or more 0 dimensions.
+   * Returns whether the number of rows or columns (or both) is zero.
    */
   isEmpty(): boolean;
 

--- a/src/__tests__/decompositions/cholesky.js
+++ b/src/__tests__/decompositions/cholesky.js
@@ -42,6 +42,10 @@ describe('Cholesky decomposition', () => {
     expect(choAtA.isPositiveDefinite()).toStrictEqual(false);
     expect(() => choAtA.solve(b)).toThrow('Matrix is not positive definite');
   });
+  it('should handle empty matrices', () => {
+    const decomp = new CHO([]);
+    expect(decomp.lowerTriangularMatrix.to2DArray()).toStrictEqual([]);
+  });
 });
 
 function checkTriangular(matrix) {

--- a/src/__tests__/decompositions/evd.js
+++ b/src/__tests__/decompositions/evd.js
@@ -13,4 +13,9 @@ describe('Eigenvalue decomposition', () => {
       [0, 3],
     ]);
   });
+
+  it('empty matrix', () => {
+    const matrix = new Matrix([]);
+    expect(() => new EVD(matrix)).toThrow('Matrix must be non-empty');
+  });
 });

--- a/src/__tests__/decompositions/lu.js
+++ b/src/__tests__/decompositions/lu.js
@@ -46,6 +46,15 @@ describe('LU decomposition', () => {
         ]).determinant,
     ).toThrow('Matrix must be square');
   });
+
+  it('should handle empty matrices', () => {
+    const matrix = new Matrix([]);
+    const decomp = new LU(matrix);
+    expect(decomp.lowerTriangularMatrix.to2DArray()).toStrictEqual([]);
+    expect(decomp.upperTriangularMatrix.to2DArray()).toStrictEqual([]);
+    // https://en.wikipedia.org/wiki/Matrix_(mathematics)#Empty_matrices
+    expect(decomp.determinant).toStrictEqual(1);
+  });
 });
 
 function checkTriangular(matrix) {

--- a/src/__tests__/decompositions/qr.js
+++ b/src/__tests__/decompositions/qr.js
@@ -63,4 +63,12 @@ describe('Qr decomposition', () => {
     const qR = Q.mmul(R);
     expect(qR.to2DArray()).toBeDeepCloseTo(A, 4);
   });
+
+  it('should work with empty matrices', () => {
+    const matrix = new Matrix([]);
+    const decomp = new QR(matrix);
+    expect(decomp.upperTriangularMatrix.to2DArray()).toStrictEqual([]);
+    expect(decomp.orthogonalMatrix.to2DArray()).toStrictEqual([]);
+    expect(decomp.isFullRank()).toStrictEqual(true);
+  });
 });

--- a/src/__tests__/decompositions/svd.js
+++ b/src/__tests__/decompositions/svd.js
@@ -336,7 +336,7 @@ describe('Singular value decomposition', () => {
   });
 
   describe('empty matrix', () => {
-    it('should produce a set of empty decomposition matrices', () => {
+    it('should throw for an empty matrix', () => {
       const matrix = new Matrix([]);
       expect(() => new SVD(matrix)).toThrow('Matrix must be non-empty');
     });

--- a/src/__tests__/decompositions/svd.js
+++ b/src/__tests__/decompositions/svd.js
@@ -334,4 +334,11 @@ describe('Singular value decomposition', () => {
       expect(actual).toBeDeepCloseTo(output, 8);
     });
   });
+
+  describe('empty matrix', () => {
+    it('should produce a set of empty decomposition matrices', () => {
+      const matrix = new Matrix([]);
+      expect(() => new SVD(matrix)).toThrow('Matrix must be non-empty');
+    });
+  });
 });

--- a/src/__tests__/matrix/creation.js
+++ b/src/__tests__/matrix/creation.js
@@ -18,22 +18,28 @@ describe('Matrix creation', () => {
     expect(matrix).toStrictEqual(original);
   });
 
-  it('should create an empty matrix', () => {
+  it('should create a zero matrix', () => {
     let matrix = new Matrix(3, 9);
     expect(matrix.rows).toBe(3);
     expect(matrix.columns).toBe(9);
     expect(matrix.get(0, 0)).toBe(0);
   });
 
+  it('should create an empty  matrix', () => {
+    const matrix00 = new Matrix(0, 0);
+    expect(matrix00.rows).toBe(0);
+    expect(matrix00.columns).toBe(0);
+    const matrix01 = new Matrix(0, 1);
+    expect(matrix01.rows).toBe(0);
+    expect(matrix01.columns).toBe(1);
+    const matrix00FromArray = new Matrix([[]]);
+    expect(matrix00FromArray.rows).toBe(1);
+    expect(matrix00FromArray.columns).toBe(0);
+  });
+
   it('should throw with wrong arguments', () => {
     expect(() => new Matrix(6, -1)).toThrow(
       /^nColumns must be a positive integer/,
-    );
-    expect(() => new Matrix(0, 0)).toThrow(
-      /^First argument must be a positive number or an array$/,
-    );
-    expect(() => new Matrix([[]])).toThrow(
-      /^Data must be a 2D array with at least one element$/,
     );
     expect(() => new Matrix([0, 1, 2, 3])).toThrow(/^Data must be a 2D array/);
     expect(
@@ -137,6 +143,9 @@ describe('Matrix creation', () => {
       [0, 1],
       [0, 0],
     ]);
+
+    let eye0 = Matrix.eye(0, 0);
+    expect(eye0.to2DArray()).toStrictEqual([]);
   });
 
   it('eye with other value than 1', () => {
@@ -172,6 +181,9 @@ describe('Matrix creation', () => {
       [0, 0, 3, 0],
       [0, 0, 0, 0],
     ]);
+    expect(Matrix.diag([], 0, 0).to2DArray()).toStrictEqual([]);
+    expect(Matrix.diag([[]], 1, 0).to2DArray()).toStrictEqual([[]]);
+    expect(Matrix.diag([], 0, 2).to2DArray()).toStrictEqual([]);
   });
 
   it('views should return new instances of Matrix', () => {

--- a/src/__tests__/matrix/flip.js
+++ b/src/__tests__/matrix/flip.js
@@ -13,6 +13,13 @@ test('flip rows', () => {
   ]);
 });
 
+test('flip rows of 0 row matrix', () => {
+  const matrix = new Matrix([]);
+  const result = matrix.flipRows();
+  expect(result).toBe(matrix);
+  expect(result.to2DArray()).toStrictEqual([]);
+});
+
 test('flip columns', () => {
   const matrix = new Matrix([
     [1, 2, 3],
@@ -24,4 +31,12 @@ test('flip columns', () => {
     [4, 5, 6],
     [1, 2, 3],
   ]);
+});
+
+test('flip columns of 0 row matrix', () => {
+  const matrix = new Matrix(0, 5);
+  const result = matrix.flipColumns();
+  expect(result).toBe(matrix);
+  expect(result.rows).toBe(0);
+  expect(result.columns).toBe(5);
 });

--- a/src/__tests__/matrix/kronecker.js
+++ b/src/__tests__/matrix/kronecker.js
@@ -18,4 +18,23 @@ describe('Kronecker product', () => {
       [18, 21, 24, 28],
     ]);
   });
+
+  it('should compute on empty matrices', () => {
+    const matrix1 = new Matrix([[]]);
+    const matrix2 = new Matrix(0, 3);
+    const matrix3 = new Matrix([
+      [0, 5],
+      [6, 7],
+    ]);
+    const product12 = matrix1.kroneckerProduct(matrix2);
+    const product13 = matrix1.kroneckerProduct(matrix3);
+    const product23 = matrix2.kroneckerProduct(matrix3);
+
+    expect(product12.rows).toBe(0);
+    expect(product12.columns).toBe(0);
+    expect(product13.rows).toBe(2);
+    expect(product13.columns).toBe(0);
+    expect(product23.rows).toBe(0);
+    expect(product23.columns).toBe(6);
+  });
 });

--- a/src/__tests__/matrix/mean.js
+++ b/src/__tests__/matrix/mean.js
@@ -5,6 +5,8 @@ describe('mean by row and columns', () => {
     [1, 2, 3],
     [4, 5, 6],
   ]);
+  const zeroRowMatrix = new Matrix(0, 2);
+  const zeroColumnMatrix = new Matrix(1, 0);
   it('mean by row', () => {
     expect(matrix.mean('row')).toStrictEqual([2, 5]);
   });
@@ -15,5 +17,17 @@ describe('mean by row and columns', () => {
 
   it('mean all', () => {
     expect(matrix.mean()).toBe(3.5);
+  });
+
+  it('means of 0 row matrix', () => {
+    expect(zeroRowMatrix.mean('row')).toStrictEqual([]);
+    expect(zeroRowMatrix.mean('column')).toStrictEqual([NaN, NaN]);
+    expect(zeroRowMatrix.mean()).toStrictEqual(NaN);
+  });
+
+  it('means of 0 column matrix', () => {
+    expect(zeroColumnMatrix.mean('row')).toStrictEqual([NaN]);
+    expect(zeroColumnMatrix.mean('column')).toStrictEqual([]);
+    expect(zeroColumnMatrix.mean()).toStrictEqual(NaN);
   });
 });

--- a/src/__tests__/matrix/minMax.js
+++ b/src/__tests__/matrix/minMax.js
@@ -10,6 +10,9 @@ describe('min - max', () => {
     [-6, 2, 12],
   ]);
 
+  const empty1 = new Matrix(2, 0);
+  const empty2 = new Matrix(2, 0);
+
   it('min', () => {
     expect(Matrix.min(matrix1, matrix2).to2DArray()).toStrictEqual([
       [0, 0, 2],
@@ -22,5 +25,13 @@ describe('min - max', () => {
       [3, 1, 2],
       [3, 4, 12],
     ]);
+  });
+
+  it('empty matrix max', () => {
+    expect(Matrix.max(empty1, empty2).to2DArray()).toStrictEqual([[], []]);
+  });
+
+  it('empty matrix min', () => {
+    expect(Matrix.min(empty1, empty2).to2DArray()).toStrictEqual([[], []]);
   });
 });

--- a/src/__tests__/matrix/minMax.js
+++ b/src/__tests__/matrix/minMax.js
@@ -1,6 +1,7 @@
 import { Matrix } from '../..';
+import { getSquareMatrix } from '../../../testUtils';
 
-describe('min - max', () => {
+describe('elementwise min - max', () => {
   const matrix1 = new Matrix([
     [0, 1, 2],
     [3, 4, 5],
@@ -33,5 +34,102 @@ describe('min - max', () => {
 
   it('empty matrix min', () => {
     expect(Matrix.min(empty1, empty2).to2DArray()).toStrictEqual([[], []]);
+  });
+});
+
+describe('matrix min/max', () => {
+  it('empty matrix', () => {
+    const emptyMatrix = new Matrix(0, 3);
+    const min = emptyMatrix.min();
+    const max = emptyMatrix.max();
+
+    expect(min).toBe(NaN);
+    expect(max).toBe(NaN);
+
+    expect(() => emptyMatrix.maxIndex()).toThrow(
+      'Empty matrix has no elements to index',
+    );
+    expect(() => emptyMatrix.minIndex()).toThrow(
+      'Empty matrix has no elements to index',
+    );
+  });
+
+  it('3x2 matrix', () => {
+    const mat = new Matrix([
+      [1, 2],
+      [7, 3],
+      [-1, 5],
+    ]);
+    const min = mat.min();
+    const max = mat.max();
+    const minIndex = mat.minIndex();
+    const maxIndex = mat.maxIndex();
+    expect(min).toBe(-1);
+    expect(max).toBe(7);
+    expect(minIndex).toStrictEqual([2, 0]);
+    expect(maxIndex).toStrictEqual([1, 0]);
+  });
+});
+
+describe('vector min/max', () => {
+  const emptyMatrix = new Matrix(0, 0);
+  const zeroRowMatrix = new Matrix(0, 2);
+  const zeroColumnMatrix = new Matrix(3, 0);
+  const squareMatrix = getSquareMatrix();
+
+  it('maxRowIndex', () => {
+    expect(() => emptyMatrix.maxRowIndex(0)).toThrow('Row index out of range');
+    expect(() => zeroColumnMatrix.maxRowIndex(0)).toThrow(
+      'Empty matrix has no elements to index',
+    );
+    expect(squareMatrix.maxRowIndex(0)).toStrictEqual([0, 1]);
+  });
+
+  it('minRowIndex', () => {
+    expect(() => emptyMatrix.minRowIndex(0)).toThrow('Row index out of range');
+    expect(() => zeroColumnMatrix.minRowIndex(0)).toThrow(
+      'Empty matrix has no elements to index',
+    );
+    expect(squareMatrix.minRowIndex(0)).toStrictEqual([0, 2]);
+  });
+
+  it('maxColumnIndex', () => {
+    expect(() => emptyMatrix.maxColumnIndex(0)).toThrow(
+      'Column index out of range',
+    );
+    expect(() => zeroRowMatrix.maxColumnIndex(0)).toThrow(
+      'Empty matrix has no elements to index',
+    );
+    expect(squareMatrix.maxColumnIndex(2)).toStrictEqual([1, 2]);
+  });
+
+  it('minColumnIndex', () => {
+    expect(() => emptyMatrix.minColumnIndex(0)).toThrow(
+      'Column index out of range',
+    );
+    expect(() => zeroRowMatrix.minColumnIndex(0)).toThrow(
+      'Empty matrix has no elements to index',
+    );
+    expect(squareMatrix.minColumnIndex(2)).toStrictEqual([2, 2]);
+  });
+
+  it('maxRow', () => {
+    expect(zeroColumnMatrix.maxRow(0)).toBe(NaN);
+    expect(squareMatrix.maxRow(1)).toBe(11);
+  });
+
+  it('minRow', () => {
+    expect(zeroColumnMatrix.minRow(0)).toBe(NaN);
+    expect(squareMatrix.minRow(1)).toBe(1);
+  });
+
+  it('maxColumn', () => {
+    expect(zeroRowMatrix.maxColumn(0)).toBe(NaN);
+    expect(squareMatrix.maxColumn(0)).toBe(9);
+  });
+
+  it('minColumn', () => {
+    expect(zeroRowMatrix.minColumn(0)).toBe(NaN);
+    expect(squareMatrix.minColumn(0)).toBe(1);
   });
 });

--- a/src/__tests__/matrix/product.js
+++ b/src/__tests__/matrix/product.js
@@ -26,7 +26,7 @@ describe('product by row and columns', () => {
   });
 
   it('product by column of empty matrix', () => {
-    expect(emptyMatrix.product('row')).toStrictEqual([]);
+    expect(emptyMatrix.product('column')).toStrictEqual([]);
   });
 
   it('product by column of 0 row matrix', () => {

--- a/src/__tests__/matrix/product.js
+++ b/src/__tests__/matrix/product.js
@@ -5,6 +5,10 @@ describe('product by row and columns', () => {
     [1, 2, 3],
     [4, 5, 6],
   ]);
+  const emptyMatrix = new Matrix(0, 0);
+  const zeroRowMatrix = new Matrix(0, 2);
+  const zeroColumnMatrix = new Matrix(3, 0);
+
   it('product by row', () => {
     expect(matrix.product('row')).toStrictEqual([6, 120]);
   });
@@ -15,5 +19,21 @@ describe('product by row and columns', () => {
 
   it('product all', () => {
     expect(matrix.product()).toBe(720);
+  });
+
+  it('product by row of empty matrix', () => {
+    expect(emptyMatrix.product('row')).toStrictEqual([]);
+  });
+
+  it('product by column of empty matrix', () => {
+    expect(emptyMatrix.product('row')).toStrictEqual([]);
+  });
+
+  it('product by column of 0 row matrix', () => {
+    expect(zeroRowMatrix.product('column')).toStrictEqual([1, 1]);
+  });
+
+  it('product by row of 0 column matrix', () => {
+    expect(zeroColumnMatrix.product('row')).toStrictEqual([1, 1, 1]);
   });
 });

--- a/src/__tests__/matrix/sum.js
+++ b/src/__tests__/matrix/sum.js
@@ -5,6 +5,10 @@ describe('sum by row and columns', () => {
     [1, 2, 3],
     [4, 5, 6],
   ]);
+  const emptyMatrix = new Matrix(0, 0);
+  const zeroRowMatrix = new Matrix(0, 2);
+  const zeroColumnMatrix = new Matrix(3, 0);
+
   it('sum by row', () => {
     expect(matrix.sum('row')).toStrictEqual([6, 15]);
   });
@@ -15,5 +19,26 @@ describe('sum by row and columns', () => {
 
   it('sum all', () => {
     expect(matrix.sum()).toBe(21);
+  });
+
+  it('sum by row of 0x0 matrix', () => {
+    expect(emptyMatrix.sum('row')).toStrictEqual([]);
+  });
+
+  it('sum by column of 0x0 matrix', () => {
+    expect(emptyMatrix.sum('column')).toStrictEqual([]);
+  });
+
+  it('sum all of 0x0 matrix', () => {
+    expect(emptyMatrix.sum()).toStrictEqual(0);
+  });
+
+  /* these correspond to the empty sum: https://en.wikipedia.org/wiki/Empty_sum */
+  it('sum by column of 0 row matrix', () => {
+    expect(zeroRowMatrix.sum('column')).toStrictEqual([0, 0]);
+  });
+
+  it('sum by row of 0 column matrix', () => {
+    expect(zeroColumnMatrix.sum('row')).toStrictEqual([0, 0, 0]);
   });
 });

--- a/src/__tests__/matrix/utility.js
+++ b/src/__tests__/matrix/utility.js
@@ -426,10 +426,10 @@ describe('utility methods', () => {
     expect(result[2][0]).toBeCloseTo(0.24390244, 5);
     expect(result[2][1]).toBeCloseTo(0.07317073, 5);
 
-    result = pseudoInverse(zeroColumnMatrix);
+    result = pseudoInverse(zeroColumnMatrix).to2DArray();
     expect(result).toStrictEqual([]);
 
-    result = pseudoInverse(zeroRowMatrix);
+    result = pseudoInverse(zeroRowMatrix).to2DArray();
     expect(result).toStrictEqual([[], []]);
   });
 

--- a/src/__tests__/matrix/utility.js
+++ b/src/__tests__/matrix/utility.js
@@ -328,7 +328,7 @@ describe('utility methods', () => {
   it('mmul strassen on empty matrices', () => {
     // https://github.com/mljs/matrix/issues/114
     // while the mathematically correct result is 0x0, we assert a 2x2 padded result that the current implementation produces
-    // (this call is actually just delegated to block multiplication in mmul())
+    // (this call is actually just delegated to standard multiplication in mmul())
     expect(
       new Matrix(0, 2).mmulStrassen(new Matrix(2, 0)).to2DArray(),
     ).toStrictEqual([
@@ -576,7 +576,7 @@ describe('utility methods', () => {
     );
   });
 
-  it('block multiplication', () => {
+  it('simple multiplication', () => {
     const empty1 = new Matrix(3, 0);
     const empty2 = new Matrix(0, 3);
     const mat1 = new Matrix([
@@ -596,6 +596,10 @@ describe('utility methods', () => {
     expect(empty1.mmul(empty2).to2DArray()).toStrictEqual(
       Matrix.zeros(3, 3).to2DArray(),
     );
+
+    const emptyMult = mat2.mmul(empty1);
+    expect(emptyMult.rows).toStrictEqual(2);
+    expect(emptyMult.columns).toStrictEqual(0);
   });
 
   it('columns and rows modification', () => {

--- a/src/__tests__/matrix/utility.js
+++ b/src/__tests__/matrix/utility.js
@@ -569,4 +569,57 @@ describe('utility methods', () => {
     zeroColumnMatrix.neg();
     expect(zeroColumnMatrix.to2DArray()).toStrictEqual([[], [], []]);
   });
+
+  it('dot product', () => {
+    expect(new Matrix([[1, 2, 3]]).dot(new Matrix([[3, 2, 1]]))).toStrictEqual(
+      10,
+    );
+  });
+
+  it('block multiplication', () => {
+    const empty1 = new Matrix(3, 0);
+    const empty2 = new Matrix(0, 3);
+    const mat1 = new Matrix([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+    const mat2 = new Matrix([
+      [6, 5, 4],
+      [3, 2, 1],
+    ]);
+
+    expect(mat2.mmul(mat1).to2DArray()).toStrictEqual([
+      [6 * 1 + 5 * 3 + 4 * 5, 6 * 2 + 5 * 4 + 4 * 6],
+      [3 * 1 + 2 * 3 + 1 * 5, 3 * 2 + 2 * 4 + 1 * 6],
+    ]);
+    expect(empty1.mmul(empty2).to2DArray()).toStrictEqual(
+      Matrix.zeros(3, 3).to2DArray(),
+    );
+  });
+
+  it('columns and rows modification', () => {
+    expect(zeroRowMatrix.removeColumn(1).columns).toStrictEqual(1);
+    expect(zeroColumnMatrix.removeRow(2).rows).toStrictEqual(2);
+
+    expect(squareMatrix.removeColumn(0).to2DArray()).toStrictEqual([
+      [13, 5],
+      [11, 7],
+      [6, 3],
+    ]);
+    expect(squareMatrix.removeRow(1).to2DArray()).toStrictEqual([
+      [13, 5],
+      [6, 3],
+    ]);
+    expect(squareMatrix.addRow(0, [1, 11]).to2DArray()).toStrictEqual([
+      [1, 11],
+      [13, 5],
+      [6, 3],
+    ]);
+    expect(squareMatrix.addColumn(2, [2, 22, 222]).to2DArray()).toStrictEqual([
+      [1, 11, 2],
+      [13, 5, 22],
+      [6, 3, 222],
+    ]);
+  });
 });

--- a/src/__tests__/stat/center.js
+++ b/src/__tests__/stat/center.js
@@ -1,6 +1,15 @@
 import { Matrix } from '../..';
 
 describe('Centering matrix', () => {
+  let emptyMatrix;
+  let zeroRowMatrix;
+  let zeroColumnMatrix;
+  beforeEach(() => {
+    emptyMatrix = new Matrix(0, 0);
+    zeroRowMatrix = new Matrix(0, 3);
+    zeroColumnMatrix = new Matrix(2, 0);
+  });
+
   it('center should work for centering rows, columns and the whole matrix', () => {
     let x = new Matrix([
       [1, 2, 3, 4, 5],
@@ -34,5 +43,41 @@ describe('Centering matrix', () => {
     expect(
       Array.from(x.clone().center('column').data[2].map(Math.round)),
     ).toStrictEqual([5, 5, 5, 5, 5]);
+  });
+
+  it('should center by row for an empty matrix', () => {
+    emptyMatrix.center('row');
+    expect(emptyMatrix.rows).toBe(0);
+    expect(emptyMatrix.columns).toBe(0);
+    zeroRowMatrix.center('row');
+    expect(zeroRowMatrix.rows).toBe(0);
+    expect(zeroRowMatrix.columns).toBe(3);
+    zeroColumnMatrix.center('row');
+    expect(zeroColumnMatrix.rows).toBe(2);
+    expect(zeroColumnMatrix.columns).toBe(0);
+  });
+
+  it('should center by column for an empty matrix', () => {
+    emptyMatrix.center('column');
+    expect(emptyMatrix.rows).toBe(0);
+    expect(emptyMatrix.columns).toBe(0);
+    zeroRowMatrix.center('column');
+    expect(zeroRowMatrix.rows).toBe(0);
+    expect(zeroRowMatrix.columns).toBe(3);
+    zeroColumnMatrix.center('column');
+    expect(zeroColumnMatrix.rows).toBe(2);
+    expect(zeroColumnMatrix.columns).toBe(0);
+  });
+
+  it('should center for an empty matrix', () => {
+    emptyMatrix.center();
+    expect(emptyMatrix.rows).toBe(0);
+    expect(emptyMatrix.columns).toBe(0);
+    zeroRowMatrix.center();
+    expect(zeroRowMatrix.rows).toBe(0);
+    expect(zeroRowMatrix.columns).toBe(3);
+    zeroColumnMatrix.center();
+    expect(zeroColumnMatrix.rows).toBe(2);
+    expect(zeroColumnMatrix.columns).toBe(0);
   });
 });

--- a/src/__tests__/stat/correlation.js
+++ b/src/__tests__/stat/correlation.js
@@ -50,4 +50,16 @@ describe('multivariate linear regression', () => {
     expect(x.to1DArray()).toStrictEqual([1, 2, 3, 4, 3, 6, 7, 1, 9]);
     expect(y.to1DArray()).toStrictEqual([5, 2, 3, 4, 1, 6, 7, 1, 7]);
   });
+  it('correlation should work on empty matrices', () => {
+    const x = new Matrix(0, 0);
+    const y = new Matrix(0, 3);
+    const z = new Matrix(3, 0);
+    expect(correlation(x).to2DArray()).toStrictEqual([]);
+    expect(correlation(y).to2DArray()).toStrictEqual([
+      [NaN, NaN, NaN],
+      [NaN, NaN, NaN],
+      [NaN, NaN, NaN],
+    ]);
+    expect(correlation(z).to2DArray()).toStrictEqual([]);
+  });
 });

--- a/src/__tests__/stat/covariance.js
+++ b/src/__tests__/stat/covariance.js
@@ -1,4 +1,4 @@
-import {Matrix, covariance, correlation} from '../..';
+import { Matrix, covariance } from '../..';
 
 describe('multivariate linear regression', () => {
   it('covariance should work with 1 or 2 matrix inputs', () => {

--- a/src/__tests__/stat/covariance.js
+++ b/src/__tests__/stat/covariance.js
@@ -1,4 +1,4 @@
-import { Matrix, covariance } from '../..';
+import {Matrix, covariance, correlation} from '../..';
 
 describe('multivariate linear regression', () => {
   it('covariance should work with 1 or 2 matrix inputs', () => {
@@ -55,5 +55,12 @@ describe('multivariate linear regression', () => {
     covariance(x, y);
     expect(x.to1DArray()).toStrictEqual([1, 2, 3, 4, 3, 6, 7, 1, 9]);
     expect(y.to1DArray()).toStrictEqual([5, 2, 3, 4, 1, 6, 7, 1, 7]);
+  });
+
+  it('covariance should work on empty matrices', () => {
+    const x = new Matrix(0, 0);
+    const z = new Matrix(3, 0);
+    expect(covariance(x).to2DArray()).toStrictEqual([]);
+    expect(covariance(z).to2DArray()).toStrictEqual([]);
   });
 });

--- a/src/__tests__/stat/scale.js
+++ b/src/__tests__/stat/scale.js
@@ -1,6 +1,14 @@
 import { Matrix } from '../..';
 
 describe('scale matrix', () => {
+  let emptyMatrix;
+  let zeroRowMatrix;
+  let zeroColumnMatrix;
+  beforeEach(() => {
+    emptyMatrix = new Matrix(0, 0);
+    zeroRowMatrix = new Matrix(0, 3);
+    zeroColumnMatrix = new Matrix(2, 0);
+  });
   it('should scale by row', () => {
     const y = new Matrix([
       [1, 2, 3, 4, 5],
@@ -19,6 +27,18 @@ describe('scale matrix', () => {
     ]);
   });
 
+  it('should scale by row for an empty matrix', () => {
+    emptyMatrix.scale('row');
+    expect(emptyMatrix.rows).toBe(0);
+    expect(emptyMatrix.columns).toBe(0);
+    zeroRowMatrix.scale('row');
+    expect(zeroRowMatrix.rows).toBe(0);
+    expect(zeroRowMatrix.columns).toBe(3);
+    zeroColumnMatrix.scale('row');
+    expect(zeroColumnMatrix.rows).toBe(2);
+    expect(zeroColumnMatrix.columns).toBe(0);
+  });
+
   it('should scale by column', () => {
     const y = new Matrix([
       [1, 2, 3, 4, 5],
@@ -35,5 +55,17 @@ describe('scale matrix', () => {
       0.26967994498529685,
       0.26967994498529685,
     ]);
+  });
+
+  it('should scale by column for an empty matrix', () => {
+    emptyMatrix.scale('column');
+    expect(emptyMatrix.rows).toBe(0);
+    expect(emptyMatrix.columns).toBe(0);
+    zeroRowMatrix.scale('column');
+    expect(zeroRowMatrix.rows).toBe(0);
+    expect(zeroRowMatrix.columns).toBe(3);
+    zeroColumnMatrix.scale('column');
+    expect(zeroColumnMatrix.rows).toBe(2);
+    expect(zeroColumnMatrix.columns).toBe(0);
   });
 });

--- a/src/dc/evd.js
+++ b/src/dc/evd.js
@@ -12,6 +12,10 @@ export default class EigenvalueDecomposition {
       throw new Error('Matrix is not a square matrix');
     }
 
+    if (matrix.isEmpty()) {
+      throw new Error('Matrix must be non-empty');
+    }
+
     let n = matrix.columns;
     let V = new Matrix(n, n);
     let d = new Float64Array(n);

--- a/src/dc/svd.js
+++ b/src/dc/svd.js
@@ -7,6 +7,10 @@ export default class SingularValueDecomposition {
   constructor(value, options = {}) {
     value = WrapperMatrix2D.checkMatrix(value);
 
+    if (value.isEmpty()) {
+      throw new Error('Matrix must be non-empty');
+    }
+
     let m = value.rows;
     let n = value.columns;
 

--- a/src/determinant.js
+++ b/src/determinant.js
@@ -5,6 +5,10 @@ import MatrixSelectionView from './views/selection';
 export function determinant(matrix) {
   matrix = Matrix.checkMatrix(matrix);
   if (matrix.isSquare()) {
+    if (matrix.columns === 0) {
+      return 1;
+    }
+
     let a, b, c, d;
     if (matrix.columns === 2) {
       // 2 x 2 matrix

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -29,6 +29,7 @@ import {
   checkColumnVector,
   checkRange,
   checkIndices,
+  checkNonEmpty,
 } from './util';
 
 export class AbstractMatrix {
@@ -574,11 +575,8 @@ export class AbstractMatrix {
     return v;
   }
 
-  // TODO test cases
   maxIndex() {
-    if (this.isEmpty()) {
-      throw new Error('Empty matrix has elements to index');
-    }
+    checkNonEmpty(this);
     let v = this.get(0, 0);
     let idx = [0, 0];
     for (let i = 0; i < this.rows; i++) {
@@ -608,11 +606,8 @@ export class AbstractMatrix {
     return v;
   }
 
-  // TODO test cases
   minIndex() {
-    if (this.isEmpty()) {
-      throw new Error('Empty matrix has elements to index');
-    }
+    checkNonEmpty(this);
     let v = this.get(0, 0);
     let idx = [0, 0];
     for (let i = 0; i < this.rows; i++) {
@@ -629,6 +624,9 @@ export class AbstractMatrix {
 
   maxRow(row) {
     checkRowIndex(this, row);
+    if (this.isEmpty()) {
+      return NaN;
+    }
     let v = this.get(row, 0);
     for (let i = 1; i < this.columns; i++) {
       if (this.get(row, i) > v) {
@@ -640,6 +638,7 @@ export class AbstractMatrix {
 
   maxRowIndex(row) {
     checkRowIndex(this, row);
+    checkNonEmpty(this);
     let v = this.get(row, 0);
     let idx = [row, 0];
     for (let i = 1; i < this.columns; i++) {
@@ -653,6 +652,9 @@ export class AbstractMatrix {
 
   minRow(row) {
     checkRowIndex(this, row);
+    if (this.isEmpty()) {
+      return NaN;
+    }
     let v = this.get(row, 0);
     for (let i = 1; i < this.columns; i++) {
       if (this.get(row, i) < v) {
@@ -664,6 +666,7 @@ export class AbstractMatrix {
 
   minRowIndex(row) {
     checkRowIndex(this, row);
+    checkNonEmpty(this);
     let v = this.get(row, 0);
     let idx = [row, 0];
     for (let i = 1; i < this.columns; i++) {
@@ -677,6 +680,9 @@ export class AbstractMatrix {
 
   maxColumn(column) {
     checkColumnIndex(this, column);
+    if (this.isEmpty()) {
+      return NaN;
+    }
     let v = this.get(0, column);
     for (let i = 1; i < this.rows; i++) {
       if (this.get(i, column) > v) {
@@ -688,6 +694,7 @@ export class AbstractMatrix {
 
   maxColumnIndex(column) {
     checkColumnIndex(this, column);
+    checkNonEmpty(this);
     let v = this.get(0, column);
     let idx = [0, column];
     for (let i = 1; i < this.rows; i++) {
@@ -701,6 +708,9 @@ export class AbstractMatrix {
 
   minColumn(column) {
     checkColumnIndex(this, column);
+    if (this.isEmpty()) {
+      return NaN;
+    }
     let v = this.get(0, column);
     for (let i = 1; i < this.rows; i++) {
       if (this.get(i, column) < v) {
@@ -712,6 +722,7 @@ export class AbstractMatrix {
 
   minColumnIndex(column) {
     checkColumnIndex(this, column);
+    checkNonEmpty(this);
     let v = this.get(0, column);
     let idx = [0, column];
     for (let i = 1; i < this.rows; i++) {
@@ -759,7 +770,6 @@ export class AbstractMatrix {
     return this;
   }
 
-  // TODO tests?
   dot(vector2) {
     if (AbstractMatrix.isMatrix(vector2)) vector2 = vector2.to1DArray();
     let vector1 = this.to1DArray();
@@ -773,7 +783,6 @@ export class AbstractMatrix {
     return dot;
   }
 
-  // TODO tests? we test strassen but not this
   mmul(other) {
     other = Matrix.checkMatrix(other);
 
@@ -1501,7 +1510,6 @@ export default class Matrix extends AbstractMatrix {
     return this.data[rowIndex][columnIndex];
   }
 
-  // TODO add test
   removeRow(index) {
     checkRowIndex(this, index);
     this.data.splice(index, 1);
@@ -1521,7 +1529,6 @@ export default class Matrix extends AbstractMatrix {
     return this;
   }
 
-  // TODO add a test
   removeColumn(index) {
     checkColumnIndex(this, index);
     for (let i = 0; i < this.rows; i++) {
@@ -1538,7 +1545,6 @@ export default class Matrix extends AbstractMatrix {
     return this;
   }
 
-  // TODO add test
   addColumn(index, array) {
     if (typeof array === 'undefined') {
       array = index;

--- a/src/pseudoInverse.js
+++ b/src/pseudoInverse.js
@@ -3,6 +3,12 @@ import Matrix from './matrix';
 
 export function pseudoInverse(matrix, threshold = Number.EPSILON) {
   matrix = Matrix.checkMatrix(matrix);
+  if (matrix.isEmpty()) {
+    // with a zero dimension, the pseudo-inverse is the transpose, since all 0xn and nx0 matrices are singular
+    // (0xn)*(nx0)*(0xn) = 0xn
+    // (nx0)*(0xn)*(nx0) = nx0
+    return matrix.transpose().to2DArray();
+  }
   let svdSolution = new SVD(matrix, { autoTranspose: true });
 
   let U = svdSolution.leftSingularVectors;

--- a/src/pseudoInverse.js
+++ b/src/pseudoInverse.js
@@ -7,7 +7,7 @@ export function pseudoInverse(matrix, threshold = Number.EPSILON) {
     // with a zero dimension, the pseudo-inverse is the transpose, since all 0xn and nx0 matrices are singular
     // (0xn)*(nx0)*(0xn) = 0xn
     // (nx0)*(0xn)*(nx0) = nx0
-    return matrix.transpose().to2DArray();
+    return matrix.transpose();
   }
   let svdSolution = new SVD(matrix, { autoTranspose: true });
 

--- a/src/util.js
+++ b/src/util.js
@@ -143,3 +143,9 @@ function checkNumber(name, value) {
     throw new TypeError(`${name} must be a number`);
   }
 }
+
+export function checkNonEmpty(matrix) {
+  if (matrix.isEmpty()) {
+    throw new Error('Empty matrix has no elements to index');
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/mljs/matrix/issues/113

## Interface Changes
Constructors now accept empty arrays / 0 dimensions as input. Utility methods changing the size of a matrix (e.g. `removeColumn`) now allow production of empty matrices.

For methods with well defined or nice mathematical properties on empty matrices (e.g. inverse, determinant), we produce the expected result. 

For methods ill-defined on empty matrices (e.g. `min` or `minIndex`), we produce a mix of `NaN`s and exceptions. For example, `min` for an empty matrix produces a `NaN`, while `minIndex` throws an exception. My rationale for this distinction was that questions about the data/content of an empty matrix (e.g. `min`) should be answered with "data", while questions about non-existent metadata (e.g. `minIndex`) simply cannot be answered.  This feels arbitrary and could use other opinions.

The only new method I added was `AbstractMatrix.isEmpty`.

## Testing
I added a an empty test case to nearly every functionality in `src/__tests__`. I also added full and empty test cases to ~10 methods that weren't previously covered.