### PR TITLE
Fix optional argument for `norm()`

### DIFF
--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -579,7 +579,7 @@ export abstract class AbstractMatrix {
    * Returns the norm of a matrix.
    * @param type - Norm type. Default: `'frobenius'`.
    */
-  norm(type: 'frobenius' | 'max'): number;
+  norm(type?: 'frobenius' | 'max'): number;
 
   /**
    * Computes the cumulative sum of the matrix elements (in place, row by row).

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -802,7 +802,8 @@ export class AbstractMatrix {
     return diag;
   }
 
-  norm(type = 'frobenius') {
+  norm(type) {
+    if (type === undefined) type = 'frobenius';
     let result = 0;
     if (type === 'max') {
       return this.max();

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -803,19 +803,13 @@ export class AbstractMatrix {
   }
 
   norm(type) {
-    if (type === undefined) type = 'frobenius';
-    let result = 0;
-    if (type === 'max') {
-      return this.max();
-    } else if (type === 'frobenius') {
-      for (let i = 0; i < this.rows; i++) {
-        for (let j = 0; j < this.columns; j++) {
-          result = result + this.get(i, j) * this.get(i, j);
-        }
-      }
-      return Math.sqrt(result);
-    } else {
-      throw new RangeError(`unknown norm type: ${type}`);
+    switch (type ?? 'frobenius') {
+      case 'max':
+        return this.max();
+      case 'frobenius':
+        return Math.sqrt(this.dot(this));
+      default:
+        throw new RangeError(`unknown norm type: ${type}`);
     }
   }
 

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -802,8 +802,8 @@ export class AbstractMatrix {
     return diag;
   }
 
-  norm(type) {
-    switch (type ?? 'frobenius') {
+  norm(type = 'frobenius') {
+    switch (type) {
       case 'max':
         return this.max();
       case 'frobenius':


### PR DESCRIPTION
Previously, TypeScript did not like an argumentless `norm()`