### PR TITLE
fix: disable esModule in CJS build

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,6 +6,7 @@ export default [
   {
     input: 'src/index.js',
     output: {
+      esModule: false,
       file: 'matrix.js',
       format: 'cjs',
       exports: 'named',


### PR DESCRIPTION
Now that we have an ESM facade, it breaks default imports for bundlers.
