### PR TITLE
fix(typings): improve generator types

### DIFF
--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -853,8 +853,8 @@ export abstract class AbstractMatrix {
   [Symbol.iterator](): Generator<
     [row: number, column: number, value: number],
     void,
-    never
-  >;
+    void
+    >;
 
   /**
    * iterator from left to right, from top to bottom
@@ -863,14 +863,14 @@ export abstract class AbstractMatrix {
   entries(): Generator<
     [row: number, column: number, value: number],
     void,
-    never
+    void
   >;
 
   /**
    * iterator from left to right, from top to bottom
    * yield value
    */
-  values(): Generator<number, void, never>;
+  values(): Generator<number, void, void>;
 
   // From here we document methods dynamically generated from operators
 
@@ -1145,14 +1145,14 @@ export class SymmetricMatrix extends AbstractMatrix {
   upperRightEntries(): Generator<
     [row: number, column: number, value: number],
     void,
-    never
+    void
   >;
 
   /**
    * half iterator upper-right-corner from left to right, from top to bottom
    * yield value
    */
-  upperRightValues(): Generator<number, void, never>;
+  upperRightValues(): Generator<number, void, void>;
 }
 
 export class DistanceMatrix extends SymmetricMatrix {

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -1530,7 +1530,7 @@ export class AbstractMatrix {
   /**
    * iterator from left to right, from top to bottom
    * yield [row, column, value]
-   * @returns {Generator<[number, number, number], void, *>}
+   * @returns {Generator<[number, number, number], void, void>}
    */
   *entries() {
     for (let row = 0; row < this.rows; row++) {
@@ -1543,7 +1543,7 @@ export class AbstractMatrix {
   /**
    * iterator from left to right, from top to bottom
    * yield value
-   * @returns {Generator<number, void, *>}
+   * @returns {Generator<number, void, void>}
    */
   *values() {
     for (let row = 0; row < this.rows; row++) {

--- a/src/symmetricMatrix.js
+++ b/src/symmetricMatrix.js
@@ -215,7 +215,7 @@ export class SymmetricMatrix extends AbstractMatrix {
    * half iterator upper-right-corner from left to right, from top to bottom
    * yield [row, column, value]
    *
-   * @returns {Generator<[number, number, number], void, *>}
+   * @returns {Generator<[number, number, number], void, void>}
    */
   *upperRightEntries() {
     for (let row = 0, col = 0; row < this.diagonalSize; void 0) {
@@ -232,7 +232,7 @@ export class SymmetricMatrix extends AbstractMatrix {
    * half iterator upper-right-corner from left to right, from top to bottom
    * yield value
    *
-   * @returns {Generator<[number, number, number], void, *>}
+   * @returns {Generator<[number, number, number], void, void>}
    */
   *upperRightValues() {
     for (let row = 0, col = 0; row < this.diagonalSize; void 0) {


### PR DESCRIPTION
Previously, code like this would fail to typecheck:
```ts
import {Matrix} from "ml-matrix"
let x = [...Matrix.eye(5).values()]
```
Typescript would give the error:
> Cannot iterate value because the 'next' method of its iterator expects type 'never', but array spread will always send 'undefined'.(2764)