### PR TITLE
Fix mpow(2**n) for integer n

### DIFF
--- a/src/__tests__/matrix/mpow.test.js
+++ b/src/__tests__/matrix/mpow.test.js
@@ -11,6 +11,18 @@ describe('matrix power', () => {
     let x = new Matrix(3, 3);
     expect(() => x.mpow(-2)).toThrowError();
   });
+  it('Small integer powers', () => {
+    let m = new Matrix([
+      [1, 2],
+      [3, 4],
+    ]);
+    let mpowByMmul = Matrix.eye(2);
+    for (let i = 0; i < 10; ++i) {
+      expect(m.mpow(i)).toStrictEqual(mpowByMmul);
+      mpowByMmul = mpowByMmul.mmul(m);
+    }
+  });
+
   it('A matrix to the power 0 is identity', () => {
     expect(
       new Matrix([

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -885,7 +885,7 @@ export class AbstractMatrix {
     let result = Matrix.eye(this.rows);
     let bb = this;
     // Note: Don't bit shift. In JS, that would truncate at 32 bits
-    for (let e = scalar; e > 1; e /= 2) {
+    for (let e = scalar; e >= 1; e /= 2) {
       if ((e & 1) !== 0) {
         result = result.mmul(bb);
       }


### PR DESCRIPTION
Previously, there was a loop termination condition error which caused the wrong result when exponentiating a matrix by a power of 2.

Fix #196