### PR TITLE
fix: use relative cutoffs for singular values and residuals

### DIFF
--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -1393,7 +1393,7 @@ export interface ILinearDependenciesOptions {
   thresholdValue?: number;
 
   /**
-   * If the error is inferior to that threshold, the linear combination found is accepted and the row is dependent from other rows.
+   * If the error, relative to the magnitude of the row being explained, is inferior to that threshold, the linear combination found is accepted and the row is dependent from other rows.
    * @default `10e-10`
    */
   thresholdError?: number;
@@ -1415,7 +1415,7 @@ export function linearDependencies(
 /**
  * Returns inverse of a matrix if it exists or the pseudoinverse.
  * @param matrix
- * @param threshold - Threshold for taking inverse of singular values. Default: `Number.EPSILON`.
+ * @param threshold - Relative threshold for taking inverse of singular values. Singular values smaller than `threshold * max(rows, columns) * largestSingularValue` are treated as zero. Default: `Number.EPSILON`.
  * @returns - The (pseudo)inverted matrix.
  */
 export function pseudoInverse(matrix: MaybeMatrix, threshold?: number): Matrix;

--- a/src/__tests__/matrix/linearDependencies.test.js
+++ b/src/__tests__/matrix/linearDependencies.test.js
@@ -26,4 +26,40 @@ describe('Linear Dependencies', () => {
       3,
     );
   });
+
+  it('should not depend on the magnitude of the matrix', () => {
+    // row 3 is 2 * row 1 whatever the scale, so the result must not change
+    const rows = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [2, 4, 6],
+    ];
+    for (const k of [1e-9, 1e-3, 1, 1e3, 1e6, 1e9, 1e12]) {
+      const dependencies = linearDependencies(new Matrix(rows).mul(k));
+      expect(dependencies.to2DArray()).toBeDeepCloseTo(
+        [
+          [0, 0, 0.5],
+          [0, 0, 0],
+          [2, 0, 0],
+        ],
+        6,
+      );
+    }
+  });
+
+  it('should not report dependencies for a full rank matrix', () => {
+    const rows = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 10],
+    ];
+    for (const k of [1e-9, 1e-3, 1, 1e3, 1e6, 1e9, 1e12]) {
+      const dependencies = linearDependencies(new Matrix(rows).mul(k));
+      expect(dependencies.to2DArray()).toStrictEqual([
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ]);
+    }
+  });
 });

--- a/src/__tests__/matrix/utility.test.js
+++ b/src/__tests__/matrix/utility.test.js
@@ -578,6 +578,122 @@ describe('utility methods', () => {
     expect(result).toStrictEqual([[], []]);
   });
 
+  it('pseudoinverse of rank-deficient matrices', () => {
+    // Actual values calculated by the Numpy library
+    let result = pseudoInverse(
+      new Matrix([
+        [10, 20, 30],
+        [40, 50, 60],
+        [70, 80, 90],
+      ]),
+    ).to2DArray();
+
+    expect(result[0][0]).toBeCloseTo(-6.38888889e-2, 8);
+    expect(result[0][1]).toBeCloseTo(-1.66666667e-2, 8);
+    expect(result[0][2]).toBeCloseTo(3.05555556e-2, 8);
+
+    expect(result[1][0]).toBeCloseTo(-5.55555556e-3, 8);
+    expect(result[1][1]).toBeCloseTo(0, 8);
+    expect(result[1][2]).toBeCloseTo(5.55555556e-3, 8);
+
+    expect(result[2][0]).toBeCloseTo(5.27777778e-2, 8);
+    expect(result[2][1]).toBeCloseTo(1.66666667e-2, 8);
+    expect(result[2][2]).toBeCloseTo(-1.94444444e-2, 8);
+
+    result = pseudoInverse(
+      new Matrix([
+        [1, 2],
+        [2, 4],
+        [3, 6],
+        [4, 8],
+      ]),
+    ).to2DArray();
+
+    expect(result[0][0]).toBeCloseTo(6.66666667e-3, 8);
+    expect(result[0][1]).toBeCloseTo(1.33333333e-2, 8);
+    expect(result[0][2]).toBeCloseTo(2.0e-2, 8);
+    expect(result[0][3]).toBeCloseTo(2.66666667e-2, 8);
+
+    expect(result[1][0]).toBeCloseTo(1.33333333e-2, 8);
+    expect(result[1][1]).toBeCloseTo(2.66666667e-2, 8);
+    expect(result[1][2]).toBeCloseTo(4.0e-2, 8);
+    expect(result[1][3]).toBeCloseTo(5.33333333e-2, 8);
+  });
+
+  it('pseudoinverse is scale invariant', () => {
+    // pinv(k*A) = pinv(A)/k exactly, at any k
+    const matrices = [
+      [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      [
+        [2, 4],
+        [7, 1],
+      ],
+      [
+        [1, 2],
+        [2, 4],
+        [3, 6],
+        [4, 8],
+      ],
+      [
+        [1, 2, 3, 4],
+        [2, 4, 6, 8],
+      ],
+    ];
+
+    for (const rows of matrices) {
+      const reference = pseudoInverse(new Matrix(rows)).to2DArray();
+      for (const k of [1e-17, 1e-12, 1e-6, 1e-2, 1e2, 1e6, 1e12, 1e17]) {
+        const scaled = pseudoInverse(new Matrix(rows).mul(k)).to2DArray();
+        expectCloseRelative(
+          scaled.map((row) => row.map((value) => value * k)),
+          reference,
+        );
+      }
+    }
+  });
+
+  it('pseudoinverse satisfies the Moore-Penrose conditions', () => {
+    const matrices = [
+      [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      [
+        [4, 7],
+        [2, 6],
+      ],
+      [
+        [1, 2],
+        [2, 4],
+        [3, 6],
+        [4, 8],
+      ],
+      [
+        [1, 2, 3, 4],
+        [2, 4, 6, 8],
+      ],
+    ];
+
+    for (const rows of matrices) {
+      for (const k of [1e-8, 1, 1e8]) {
+        const A = new Matrix(rows).mul(k);
+        const P = pseudoInverse(A);
+        const AP = A.mmul(P);
+        const PA = P.mmul(A);
+
+        expectCloseRelative(AP.mmul(A).to2DArray(), A.to2DArray());
+        expectCloseRelative(PA.mmul(P).to2DArray(), P.to2DArray());
+        expectCloseRelative(AP.transpose().to2DArray(), AP.to2DArray());
+        expectCloseRelative(PA.transpose().to2DArray(), PA.to2DArray());
+      }
+    }
+  });
+
   it('isEchelonForm', () => {
     const matrix = new Matrix([
       [1, 0],
@@ -808,3 +924,21 @@ describe('utility methods', () => {
     ]);
   });
 });
+
+// Compares entries relative to the magnitude of the expected matrix, so the
+// same assertion holds for results spanning many orders of magnitude.
+function expectCloseRelative(actual, expected) {
+  let scale = 0;
+  for (const row of expected) {
+    for (const value of row) {
+      scale = Math.max(scale, Math.abs(value));
+    }
+  }
+  for (let i = 0; i < expected.length; i++) {
+    for (let j = 0; j < expected[i].length; j++) {
+      expect(Math.abs(actual[i][j] - expected[i][j])).toBeLessThan(
+        1e-12 * scale,
+      );
+    }
+  }
+}

--- a/src/linearDependencies.js
+++ b/src/linearDependencies.js
@@ -43,7 +43,9 @@ export function linearDependencies(matrix, options = {}) {
     let Abis = matrix.subMatrixRow(xrange(n, i)).transpose();
     let svd = new SingularValueDecomposition(Abis);
     let x = svd.solve(b);
-    let error = Matrix.sub(b, Abis.mmul(x)).abs().max();
+    // The residual scales with the row it explains; the coefficients don't.
+    let scale = Matrix.abs(b).max() || 1;
+    let error = Matrix.sub(b, Abis.mmul(x)).abs().max() / scale;
     results.setRow(
       i,
       dependenciesOneRow(error, x, i, thresholdValue, thresholdError),

--- a/src/pseudoInverse.js
+++ b/src/pseudoInverse.js
@@ -15,8 +15,12 @@ export function pseudoInverse(matrix, threshold = Number.EPSILON) {
   let V = svdSolution.rightSingularVectors;
   let s = svdSolution.diagonal;
 
+  // Singular values scale with the matrix, so the cutoff must too. Same
+  // tolerance as SVD.rank, and the `rcond * max(s)` rule used by LAPACK.
+  const cutoff = threshold * Math.max(matrix.rows, matrix.columns) * s[0];
+
   for (let i = 0; i < s.length; i++) {
-    if (Math.abs(s[i]) > threshold) {
+    if (Math.abs(s[i]) > cutoff) {
       s[i] = 1.0 / s[i];
     } else {
       s[i] = 0.0;


### PR DESCRIPTION
`pseudoInverse` compares singular values against an absolute constant (`Number.EPSILON`) and `linearDependencies` compares its solve residual against an absolute `10e-10`. Both quantities scale with the matrix, so both functions answer according to the *magnitude* of the input rather than its rank — in both directions:

```js
pseudoInverse(new Matrix([[1, 2], [2, 4], [3, 6], [4, 8]]));
// [[ 7.3e14, -2.5e13, -1.6e14, -4.9e13],    numpy: [[0.00667, 0.01333, 0.02, 0.02667],
//  [-3.7e14,  1.2e13,  8.1e13,  2.5e13]]            [0.01333, 0.02667, 0.04, 0.05333]]

pseudoInverse(new Matrix([[2, 4], [7, 1]]).mul(1e-17));
// [[0, 0], [0, 0]]  -- full rank and well conditioned, but every singular value
//                      is below Number.EPSILON, so all of them are discarded

linearDependencies(new Matrix([[1, 2, 3], [4, 5, 6], [2, 4, 6]]).mul(1e6));
// [[0,0,0],[0,0,0],[0,0,0]]  -- row 3 is exactly 2 * row 1, at every scale

linearDependencies(new Matrix([[1, 2, 3], [4, 5, 6], [7, 8, 10]]).mul(1e-9));
// [[0, 1.88, -0.88], [0.18, 0, 0.55], [-0.28, 1.78, 0]]  -- full rank, yet every
//                                                           row is "dependent"
```

The library already contains the correct rule: `SVD.threshold` and `SVD.rank` are relative to `s[0]`, and `SVD.solve` / `SVD.inverse` use it — so `svd.inverse()` returns the right pseudo-inverse from the very same decomposition that `pseudoInverse` gets wrong. `numpy.linalg.pinv` uses the same relative rule (`rcond * max(s)`).

**Fix.** The `pseudoInverse` cutoff becomes `threshold * max(rows, columns) * s[0]`, which is exactly `SVD.rank`'s tolerance, so the two can no longer disagree about which singular values are zero. `linearDependencies` divides the residual by the magnitude of the row it explains. `thresholdValue` stays absolute — it filters the coefficients, which are already scale-free. This changes `threshold` and `thresholdError` from absolute to relative parameters; `matrix.d.ts` is updated.

**Tests.** Five new tests, all red before the change: numpy values for two rank-deficient matrices at ordinary magnitude, `pinv(k*A) === pinv(A)/k` for `k` from 1e-17 to 1e17 over four shapes, the four Moore-Penrose conditions at three magnitudes, and scale invariance of `linearDependencies` in both directions. The existing pinned tests are unchanged and still pass (261 -> 266) — the old `pseudoinverse` test only used matrices at the one magnitude where an absolute cutoff happens to work. I also ran a property sweep over ~12.5k random cases (shapes 1..6, magnitudes 1e-18..1e18, 40% forced rank-deficient): 2042 violations before, 0 after.

One note from auditing the other tolerance constants in `src/`: the `eps * tst1` / `eps * norm` tests in `svd.js` and `evd.js` are already relative and correct, but `nipals.js` has the same shape of problem — `terminationCriteria = 1e-10` is compared against `sum((t - tOld)^2)`, which scales with the data. On the iris fixture the tests use, scaling `x` by 1e-6 moves the first loading vector from `[0.5211, -0.2693, 0.5804, 0.5649]` to `[0.5490, -0.2041, 0.5802, 0.5660]`. I left it out of this PR because making it relative also means re-picking the default constant; happy to send it separately if you want it.
