### PR TITLE
feat: add concat to join two matrices along a chosen dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ var M = new Matrix([
   [3, 4],
 ]);
 
-var stacked = M.concat([[5, 6]]);                                 // stacked = Matrix [[1, 2], [3, 4], [5, 6], rows: 3, columns: 2]
-var widened = M.concat(Matrix.columnVector([5, 6]), 'column');    // widened = Matrix [[1, 2, 5], [3, 4, 6], rows: 2, columns: 3]
+var stacked = M.concat([[5, 6]]);                              // stacked = Matrix [[1, 2], [3, 4], [5, 6], rows: 3, columns: 2]
+var widened = M.concat(Matrix.columnVector([5, 6]), 'column'); // widened = Matrix [[1, 2, 5], [3, 4, 6], rows: 2, columns: 3]
 ```
 Concatenating by row needs the same number of columns on both sides, concatenating by column needs the same number of rows. The two operands are left untouched.
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,10 @@ var M = new Matrix([
   [3, 4],
 ]);
 
-var stacked = M.concat([[5, 6]]); // stacked = Matrix [[1, 2], [3, 4], [5, 6], rows: 3, columns: 2]
+var stacked = M.concat([[5, 6]]);                                 // stacked = Matrix [[1, 2], [3, 4], [5, 6], rows: 3, columns: 2]
+var widened = M.concat(Matrix.columnVector([5, 6]), 'column');    // widened = Matrix [[1, 2, 5], [3, 4, 6], rows: 2, columns: 3]
 ```
+Concatenating by row needs the same number of columns on both sides, concatenating by column needs the same number of rows. The two operands are left untouched.
 
 #### Instantiation of matrix
 ```js

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ var norm           = A.norm();           // norm = 10.14889156509222 (Frobenius 
 var transpose      = A.transpose();      // transpose = Matrix [[1, 10], [1, -1], rows: 2, columns: 2]
 ```
 
+#### Instantiation of matrix
+```js
+var z = Matrix.zeros(3, 2); // z = Matrix [[0, 0], [0, 0], [0, 0], rows: 3, columns: 2]
+var z = Matrix.ones(2, 3);  // z = Matrix [[1, 1, 1], [1, 1, 1], rows: 2, columns: 3]
+var z = Matrix.eye(3, 4);   // z = Matrix [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], rows: 3, columns: 4]. there are 1 only in the diagonal
+```
+
 #### Concatenation of matrices
 ```js
 var M = new Matrix([
@@ -135,13 +142,6 @@ var stacked = M.concat([[5, 6]]);                              // stacked = Matr
 var widened = M.concat(Matrix.columnVector([5, 6]), 'column'); // widened = Matrix [[1, 2, 5], [3, 4, 6], rows: 2, columns: 3]
 ```
 Concatenating by row needs the same number of columns on both sides, concatenating by column needs the same number of rows. The two operands are left untouched.
-
-#### Instantiation of matrix
-```js
-var z = Matrix.zeros(3, 2); // z = Matrix [[0, 0], [0, 0], [0, 0], rows: 3, columns: 2]
-var z = Matrix.ones(2, 3);  // z = Matrix [[1, 1, 1], [1, 1, 1], rows: 2, columns: 3]
-var z = Matrix.eye(3, 4);   // z = Matrix [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], rows: 3, columns: 4]. there are 1 only in the diagonal
-```
 
 ### Maths
 ```js

--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ var norm           = A.norm();           // norm = 10.14889156509222 (Frobenius 
 var transpose      = A.transpose();      // transpose = Matrix [[1, 10], [1, -1], rows: 2, columns: 2]
 ```
 
+#### Concatenation of matrices
+```js
+var M = new Matrix([
+  [1, 2],
+  [3, 4],
+]);
+
+var stacked = M.concat([[5, 6]]); // stacked = Matrix [[1, 2], [3, 4], [5, 6], rows: 3, columns: 2]
+```
+
 #### Instantiation of matrix
 ```js
 var z = Matrix.zeros(3, 2); // z = Matrix [[0, 0], [0, 0], [0, 0], rows: 3, columns: 2]

--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -764,6 +764,15 @@ export abstract class AbstractMatrix {
   ): this;
 
   /**
+   * Returns a new matrix made of this matrix followed by the other one.
+   * Concatenating by 'row' stacks the two matrices vertically and requires the same number of columns.
+   * Concatenating by 'column' stacks them side by side and requires the same number of rows.
+   * @param other - The matrix to append.
+   * @param by - Concatenate by 'row' or 'column'. Default: `'row'`.
+   */
+  concat(other: MaybeMatrix, by?: MatrixDimension): Matrix;
+
+  /**
    * Return a new matrix based on a selection of rows and columns.
    * Order of the indices matters and the same index can be used more than once.
    * @param rowIndices - The row indices to select.

--- a/src/__tests__/matrix/concat.test.js
+++ b/src/__tests__/matrix/concat.test.js
@@ -139,6 +139,18 @@ describe('concat with degenerate matrices', () => {
     expect(result.to2DArray()).toStrictEqual([[1], [2]]);
   });
 
+  it('by column of two matrices without rows', () => {
+    const result = new Matrix(0, 1).concat(new Matrix(0, 2), 'column');
+    expect(result.rows).toBe(0);
+    expect(result.columns).toBe(3);
+  });
+
+  it('by row of two matrices without columns', () => {
+    const result = new Matrix(1, 0).concat(new Matrix(2, 0), 'row');
+    expect(result.rows).toBe(3);
+    expect(result.columns).toBe(0);
+  });
+
   it('by row of two 0x0 matrices', () => {
     const result = new Matrix(0, 0).concat(new Matrix(0, 0), 'row');
     expect(result.rows).toBe(0);

--- a/src/__tests__/matrix/concat.test.js
+++ b/src/__tests__/matrix/concat.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+
+import { Matrix, MatrixTransposeView, SymmetricMatrix } from '../..';
+
+describe('concat', () => {
+  const matrix = new Matrix([
+    [1, 2],
+    [3, 4],
+  ]);
+  const other = new Matrix([
+    [5, 6],
+    [7, 8],
+    [9, 10],
+  ]);
+
+  it('by row stacks the matrices vertically', () => {
+    const result = matrix.concat(other, 'row');
+    expect(result.rows).toBe(5);
+    expect(result.columns).toBe(2);
+    expect(result.to2DArray()).toStrictEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+      [7, 8],
+      [9, 10],
+    ]);
+  });
+
+  it('by column stacks the matrices side by side', () => {
+    const result = matrix.concat(other.transpose(), 'column');
+    expect(result.rows).toBe(2);
+    expect(result.columns).toBe(5);
+    expect(result.to2DArray()).toStrictEqual([
+      [1, 2, 5, 7, 9],
+      [3, 4, 6, 8, 10],
+    ]);
+  });
+
+  it('concatenates by row when the dimension is omitted', () => {
+    expect(matrix.concat(other).to2DArray()).toStrictEqual(
+      matrix.concat(other, 'row').to2DArray(),
+    );
+  });
+
+  it('accepts a 2D array', () => {
+    expect(matrix.concat([[5, 6]]).to2DArray()).toStrictEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+
+  it('leaves both operands untouched', () => {
+    matrix.concat(other, 'row');
+    expect(matrix.to2DArray()).toStrictEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(other.rows).toBe(3);
+  });
+
+  it('always returns a plain matrix', () => {
+    const symmetric = new SymmetricMatrix([
+      [1, 2],
+      [2, 3],
+    ]);
+    const result = symmetric.concat(matrix, 'row');
+    expect(result).toBeInstanceOf(Matrix);
+    expect(result.to2DArray()).toStrictEqual([
+      [1, 2],
+      [2, 3],
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('reads a view along the view dimensions', () => {
+    const view = new MatrixTransposeView(
+      new Matrix([
+        [1, 2, 3],
+        [4, 5, 6],
+      ]),
+    );
+    expect(view.concat([[7, 8]], 'row').to2DArray()).toStrictEqual([
+      [1, 4],
+      [2, 5],
+      [3, 6],
+      [7, 8],
+    ]);
+  });
+});
+
+describe('concat with degenerate matrices', () => {
+  it('by row with a matrix without rows', () => {
+    const result = new Matrix(0, 2).concat(new Matrix([[1, 2]]), 'row');
+    expect(result.to2DArray()).toStrictEqual([[1, 2]]);
+  });
+
+  it('by row onto a matrix without rows', () => {
+    const result = new Matrix([[1, 2]]).concat(new Matrix(0, 2), 'row');
+    expect(result.to2DArray()).toStrictEqual([[1, 2]]);
+  });
+
+  it('by column with a matrix without columns', () => {
+    const result = new Matrix(2, 0).concat(new Matrix([[1], [2]]), 'column');
+    expect(result.to2DArray()).toStrictEqual([[1], [2]]);
+  });
+
+  it('by column onto a matrix without columns', () => {
+    const result = new Matrix([[1], [2]]).concat(new Matrix(2, 0), 'column');
+    expect(result.to2DArray()).toStrictEqual([[1], [2]]);
+  });
+
+  it('by row of two 0x0 matrices', () => {
+    const result = new Matrix(0, 0).concat(new Matrix(0, 0), 'row');
+    expect(result.rows).toBe(0);
+    expect(result.columns).toBe(0);
+  });
+});
+
+describe('concat error handling', () => {
+  const matrix = new Matrix([
+    [1, 2],
+    [3, 4],
+  ]);
+
+  it('throws when the number of columns differs', () => {
+    expect(() => matrix.concat(new Matrix([[1, 2, 3]]), 'row')).toThrow(
+      /^both matrices must have the same number of columns$/,
+    );
+  });
+
+  it('throws when the number of rows differs', () => {
+    expect(() => matrix.concat(new Matrix([[1, 2, 3]]), 'column')).toThrow(
+      /^both matrices must have the same number of rows$/,
+    );
+  });
+
+  it('throws when the dimension is unknown', () => {
+    expect(() => matrix.concat(matrix, 'diagonal')).toThrow(
+      /^invalid option: diagonal$/,
+    );
+  });
+});

--- a/src/__tests__/matrix/concat.test.js
+++ b/src/__tests__/matrix/concat.test.js
@@ -88,6 +88,34 @@ describe('concat', () => {
       [7, 8],
     ]);
   });
+
+  it('appends a column vector', () => {
+    const result = matrix.concat(Matrix.columnVector([5, 6]), 'column');
+    expect(result.to2DArray()).toStrictEqual([
+      [1, 2, 5],
+      [3, 4, 6],
+    ]);
+  });
+
+  it('appends a row vector', () => {
+    const result = matrix.concat(Matrix.rowVector([5, 6]), 'row');
+    expect(result.to2DArray()).toStrictEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+
+  it('chains to gather several matrices', () => {
+    const result = matrix
+      .concat([[5, 6]], 'row')
+      .concat(Matrix.columnVector([7, 8, 9]), 'column');
+    expect(result.to2DArray()).toStrictEqual([
+      [1, 2, 7],
+      [3, 4, 8],
+      [5, 6, 9],
+    ]);
+  });
 });
 
 describe('concat with degenerate matrices', () => {

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -1420,6 +1420,36 @@ export class AbstractMatrix {
     return this;
   }
 
+  concat(other, by = 'row') {
+    other = Matrix.checkMatrix(other);
+    switch (by) {
+      case 'row': {
+        if (this.columns !== other.columns) {
+          throw new RangeError(
+            'both matrices must have the same number of columns',
+          );
+        }
+        const result = new Matrix(this.rows + other.rows, this.columns);
+        result.setSubMatrix(this, 0, 0);
+        result.setSubMatrix(other, this.rows, 0);
+        return result;
+      }
+      case 'column': {
+        if (this.rows !== other.rows) {
+          throw new RangeError(
+            'both matrices must have the same number of rows',
+          );
+        }
+        const result = new Matrix(this.rows, this.columns + other.columns);
+        result.setSubMatrix(this, 0, 0);
+        result.setSubMatrix(other, 0, this.columns);
+        return result;
+      }
+      default:
+        throw new Error(`invalid option: ${by}`);
+    }
+  }
+
   selection(rowIndices, columnIndices) {
     checkRowIndices(this, rowIndices);
     checkColumnIndices(this, columnIndices);


### PR DESCRIPTION
Closes #54.
Closes #161.

## Summary

The library has no way to join two matrices. Both linked issues ask for one, #161 pointing at the numpy `stack`, `hstack`, `vstack` equivalents. The maintainer reply on #54 proposed `matrix1.concat(matrix2)` returning a new matrix, which is the shape implemented here.

## API

```ts
concat(other: MaybeMatrix, by?: MatrixDimension): Matrix;
```

- `by === 'row'`, the default, stacks the two matrices vertically. Both operands need the same number of columns. The result has `this.rows + other.rows` rows.
- `by === 'column'` stacks them side by side. Both operands need the same number of rows. The result has `this.columns + other.columns` columns.
- `other` passes through `Matrix.checkMatrix`, meaning a plain 2D array is accepted.
- Neither operand is mutated. The result is a plain `Matrix`, including when the receiver is a view, a `SymmetricMatrix`, a `DistanceMatrix`.
- A dimension mismatch throws a `RangeError` naming the dimension that has to match. An unknown dimension throws `invalid option: <value>`, matching `sum`, `product`, `mean`.

Values are copied once into a preallocated result through `setSubMatrix`, leaving a single allocation per call. Matrices with a zero dimension are handled, which keeps the result predictable when one side carries no data.

## Example

```js
const M = new Matrix([
  [1, 2],
  [3, 4],
]);

M.concat([[5, 6]]); // Matrix [[1, 2], [3, 4], [5, 6]]
M.concat(Matrix.columnVector([5, 6]), 'column'); // Matrix [[1, 2, 5], [3, 4, 6]]
```

Chaining covers more than two operands, as in `a.concat(b).concat(c)`.

The typing in `matrix.d.ts` is updated alongside the implementation. The README gains a short example under the existing examples section.
