### PR TITLE
fix: reject matrices with fewer rows than columns in the LU and QR decompositions

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ var error = Matrix.sub(B, A.mmul(x)); // The error enables to evaluate the solut
 ```
 #### Decompositions
 
+`QrDecomposition` along with `LuDecomposition` need a matrix with at least as many rows as columns. A matrix carrying more columns than rows is rejected with a `RangeError`.
+
+`SingularValueDecomposition` is an economy decomposition, meaning a matrix of shape m by n with m at least n gives left singular vectors of shape m by n, right singular vectors of shape n by n, and n singular values. The vectors it returns therefore do not span the null space of a wide matrix. Pass `autoTranspose` to decompose a matrix carrying more columns than rows.
+
 ##### QR Decomposition
 ```js
 var A = new Matrix([

--- a/README.md
+++ b/README.md
@@ -236,8 +236,6 @@ var error = Matrix.sub(B, A.mmul(x)); // The error enables to evaluate the solut
 
 `QrDecomposition` along with `LuDecomposition` need a matrix with at least as many rows as columns. A matrix carrying more columns than rows is rejected with a `RangeError`.
 
-`SingularValueDecomposition` is an economy decomposition, meaning a matrix of shape m by n with m at least n gives left singular vectors of shape m by n, right singular vectors of shape n by n, and n singular values. The vectors it returns therefore do not span the null space of a wide matrix. Pass `autoTranspose` to decompose a matrix carrying more columns than rows.
-
 ##### QR Decomposition
 ```js
 var A = new Matrix([

--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -1475,21 +1475,12 @@ export interface ISVDOptions {
   computeRightSingularVectors?: boolean;
 
   /**
-   * Decompose the transpose when the matrix carries more columns than rows, then swap the
-   * singular vectors back. Leaving this off on such a matrix logs a warning and yields a
-   * decomposition padded to the number of columns.
    * @default `false`
    */
   autoTranspose?: boolean;
 }
 
 /**
- * The economy singular value decomposition of a matrix.
- * For a matrix of shape m by n with m at least n, the left singular vectors are m by n,
- * the right singular vectors are n by n, and n singular values are reported. The null
- * space of a wide matrix is therefore not spanned by the returned vectors.
- * Set `autoTranspose` to decompose a matrix carrying more columns than rows.
- *
  * @see https://github.com/accord-net/framework/blob/development/Sources/Accord.Math/Decompositions/SingularValueDecomposition.cs
  */
 export class SingularValueDecomposition {

--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -1475,12 +1475,21 @@ export interface ISVDOptions {
   computeRightSingularVectors?: boolean;
 
   /**
+   * Decompose the transpose when the matrix carries more columns than rows, then swap the
+   * singular vectors back. Leaving this off on such a matrix logs a warning and yields a
+   * decomposition padded to the number of columns.
    * @default `false`
    */
   autoTranspose?: boolean;
 }
 
 /**
+ * The economy singular value decomposition of a matrix.
+ * For a matrix of shape m by n with m at least n, the left singular vectors are m by n,
+ * the right singular vectors are n by n, and n singular values are reported. The null
+ * space of a wide matrix is therefore not spanned by the returned vectors.
+ * Set `autoTranspose` to decompose a matrix carrying more columns than rows.
+ *
  * @see https://github.com/accord-net/framework/blob/development/Sources/Accord.Math/Decompositions/SingularValueDecomposition.cs
  */
 export class SingularValueDecomposition {

--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -1570,6 +1570,9 @@ export class CholeskyDecomposition {
 export { CholeskyDecomposition as CHO };
 
 /**
+ * The LU decomposition of a matrix with at least as many rows as columns.
+ * A matrix carrying more columns than rows is rejected with a `RangeError`.
+ *
  * @link https://github.com/lutzroeder/Mapack/blob/master/Source/LuDecomposition.cs
  */
 export class LuDecomposition {
@@ -1585,6 +1588,9 @@ export class LuDecomposition {
 export { LuDecomposition as LU };
 
 /**
+ * The QR decomposition of a matrix with at least as many rows as columns.
+ * A matrix carrying more columns than rows is rejected with a `RangeError`.
+ *
  * @link https://github.com/lutzroeder/Mapack/blob/master/Source/QrDecomposition.cs
  */
 export class QrDecomposition {

--- a/src/__tests__/decompositions/lu.test.js
+++ b/src/__tests__/decompositions/lu.test.js
@@ -45,6 +45,15 @@ describe('LU decomposition', () => {
         new LU([
           [0, 1, 2],
           [0, 1, 2],
+        ]),
+    ).toThrow('Matrix must have at least as many rows as columns');
+
+    expect(
+      () =>
+        new LU([
+          [0, 1],
+          [0, 1],
+          [0, 1],
         ]).determinant,
     ).toThrow('Matrix must be square');
   });

--- a/src/__tests__/decompositions/shape.test.js
+++ b/src/__tests__/decompositions/shape.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  Matrix,
+  LuDecomposition,
+  QrDecomposition,
+  SingularValueDecomposition,
+  solve,
+} from '../..';
+
+const message = /^Matrix must have at least as many rows as columns$/;
+
+describe('LU and QR need at least as many rows as columns', () => {
+  const wide = new Matrix([
+    [1, 2, 3],
+    [4, 5, 6],
+  ]);
+
+  it('LU rejects a wide matrix', () => {
+    expect(() => new LuDecomposition(wide)).toThrow(message);
+  });
+
+  it('QR rejects a wide matrix', () => {
+    expect(() => new QrDecomposition(wide)).toThrow(message);
+  });
+
+  it('LU rejects a wide 2D array', () => {
+    expect(() => new LuDecomposition([[1, 2, 3, 4]])).toThrow(message);
+  });
+
+  it('QR rejects a wide 2D array', () => {
+    expect(() => new QrDecomposition([[1, 2, 3, 4]])).toThrow(message);
+  });
+
+  it('solve reports the shape rather than a rank problem', () => {
+    expect(() => solve(wide, Matrix.columnVector([1, 2]))).toThrow(message);
+  });
+});
+
+describe('LU and QR keep working on the supported shapes', () => {
+  const tall = new Matrix([
+    [1, 2],
+    [3, 4],
+    [5, 6],
+  ]);
+  const square = new Matrix([
+    [4, 3],
+    [6, 3],
+  ]);
+
+  it('QR on a tall matrix rebuilds the input', () => {
+    const qr = new QrDecomposition(tall);
+    const product = qr.orthogonalMatrix.mmul(qr.upperTriangularMatrix);
+    for (let i = 0; i < tall.rows; i++) {
+      for (let j = 0; j < tall.columns; j++) {
+        expect(product.get(i, j)).toBeCloseTo(tall.get(i, j), 10);
+      }
+    }
+  });
+
+  it('LU on a tall matrix reports a usable triangular pair', () => {
+    const lu = new LuDecomposition(tall);
+    expect(lu.lowerTriangularMatrix.rows).toBe(3);
+    expect(lu.upperTriangularMatrix.columns).toBe(2);
+  });
+
+  it('LU on a square matrix stays solvable', () => {
+    const lu = new LuDecomposition(square);
+    expect(lu.isSingular()).toBe(false);
+    const x = lu.solve(Matrix.columnVector([10, 12]));
+    const back = square.mmul(x);
+    expect(back.get(0, 0)).toBeCloseTo(10, 10);
+    expect(back.get(1, 0)).toBeCloseTo(12, 10);
+  });
+
+  it('an empty matrix is still accepted', () => {
+    expect(() => new LuDecomposition(new Matrix(0, 0))).not.toThrow();
+    expect(() => new QrDecomposition(new Matrix(0, 0))).not.toThrow();
+  });
+});
+
+describe('SVD covers the wide case through autoTranspose', () => {
+  const wide = new Matrix([
+    [1, 2, 3],
+    [4, 5, 6],
+  ]);
+
+  it('rebuilds a wide matrix with autoTranspose', () => {
+    const svd = new SingularValueDecomposition(wide, { autoTranspose: true });
+    const product = svd.leftSingularVectors
+      .mmul(Matrix.diag(svd.diagonal))
+      .mmul(svd.rightSingularVectors.transpose());
+    for (let i = 0; i < wide.rows; i++) {
+      for (let j = 0; j < wide.columns; j++) {
+        expect(product.get(i, j)).toBeCloseTo(wide.get(i, j), 10);
+      }
+    }
+  });
+
+  it('reports one singular value per row of a wide matrix', () => {
+    const svd = new SingularValueDecomposition(wide, { autoTranspose: true });
+    expect(svd.diagonal).toHaveLength(2);
+    expect(svd.rank).toBe(2);
+  });
+});

--- a/src/__tests__/decompositions/shape.test.js
+++ b/src/__tests__/decompositions/shape.test.js
@@ -1,12 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import {
-  Matrix,
-  LuDecomposition,
-  QrDecomposition,
-  SingularValueDecomposition,
-  solve,
-} from '../..';
+import { Matrix, LuDecomposition, QrDecomposition, solve } from '../..';
 
 const message = /^Matrix must have at least as many rows as columns$/;
 
@@ -76,30 +70,5 @@ describe('LU and QR keep working on the supported shapes', () => {
   it('an empty matrix is still accepted', () => {
     expect(() => new LuDecomposition(new Matrix(0, 0))).not.toThrow();
     expect(() => new QrDecomposition(new Matrix(0, 0))).not.toThrow();
-  });
-});
-
-describe('SVD covers the wide case through autoTranspose', () => {
-  const wide = new Matrix([
-    [1, 2, 3],
-    [4, 5, 6],
-  ]);
-
-  it('rebuilds a wide matrix with autoTranspose', () => {
-    const svd = new SingularValueDecomposition(wide, { autoTranspose: true });
-    const product = svd.leftSingularVectors
-      .mmul(Matrix.diag(svd.diagonal))
-      .mmul(svd.rightSingularVectors.transpose());
-    for (let i = 0; i < wide.rows; i++) {
-      for (let j = 0; j < wide.columns; j++) {
-        expect(product.get(i, j)).toBeCloseTo(wide.get(i, j), 10);
-      }
-    }
-  });
-
-  it('reports one singular value per row of a wide matrix', () => {
-    const svd = new SingularValueDecomposition(wide, { autoTranspose: true });
-    expect(svd.diagonal).toHaveLength(2);
-    expect(svd.rank).toBe(2);
   });
 });

--- a/src/dc/lu.js
+++ b/src/dc/lu.js
@@ -4,6 +4,9 @@ import WrapperMatrix2D from '../wrap/WrapperMatrix2D';
 export default class LuDecomposition {
   constructor(matrix) {
     matrix = WrapperMatrix2D.checkMatrix(matrix);
+    if (matrix.rows < matrix.columns) {
+      throw new RangeError('Matrix must have at least as many rows as columns');
+    }
 
     let lu = matrix.clone();
     let rows = lu.rows;

--- a/src/dc/qr.js
+++ b/src/dc/qr.js
@@ -6,6 +6,9 @@ import { hypotenuse } from './util';
 export default class QrDecomposition {
   constructor(value) {
     value = WrapperMatrix2D.checkMatrix(value);
+    if (value.rows < value.columns) {
+      throw new RangeError('Matrix must have at least as many rows as columns');
+    }
 
     let qr = value.clone();
     let m = value.rows;


### PR DESCRIPTION
Closes #203.

## Summary

The issue asks whether the SVD is broken for matrices carrying more columns than rows. It is not, the decomposition is an economy one and it reconstructs its input exactly. What the report gets right is that this is undocumented, and looking into it turned up two neighbouring decompositions that genuinely fall over on the same input shape.

## The SVD is correct

For the 2x3 matrix `[[1, 2, 3], [4, 5, 6]]`, both with `autoTranspose` on and off, `U * diag(s) * Vᵀ` returns the input to machine precision. The economy form reports `min(m, n)` singular values, so the vectors it hands back do not span the null space of a wide matrix. That is a property of the economy form, not a defect. This PR documents the shape contract along with the effect of `autoTranspose` in the typings and the README.

## LuDecomposition and QrDecomposition genuinely break

Both are ports of routines defined for a matrix with at least as many rows as columns. Neither checked. Feeding them a 2x3 matrix on `main`:

| call | result |
| --- | --- |
| `new LuDecomposition(wide).isSingular()` | `TypeError: Cannot read properties of undefined (reading '2')` |
| `new LuDecomposition(wide).solve(b)` | the same `TypeError` |
| `new QrDecomposition(wide).orthogonalMatrix` | `TypeError: Cannot set properties of undefined (setting '2')` |
| `new QrDecomposition(wide).householderVectors` | `TypeError: Cannot read properties of undefined` |

The accessors that avoid the crash are worse, since they hand back a triangular factor of the wrong shape with no indication anything went wrong.

Both constructors now reject that input:

```
RangeError: Matrix must have at least as many rows as columns
```

`solve` routes a non square left hand side to `QrDecomposition`, so `solve(wideMatrix, b)` reports the shape now rather than the `Matrix is rank deficient` it produced before. Callers with a wide system want `pseudoInverse`, along with `solve(a, b, true)` to go through the SVD.

Nothing that worked before stops working. Every one of these calls already failed, either loudly with an internal error or quietly with a meaningless factor.

## Notes

The `Matrix must be square` error on `determinant` is untouched. A 3x2 matrix still reaches it, a 2x3 matrix is now stopped one step earlier by the constructor.
