### PR TITLE
feat: bound the number of sweeps the SVD spends on one singular value

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ var s = svd.diagonal;
 var V = svd.rightSingularVectors;
 // U * diag(s) * V.transpose() gives A back
 ```
-The decomposition settles one singular value at a time through repeated sweeps. `maxIterations`, 100 by default, caps how many sweeps any one value gets. A decomposition that converges takes a handful per value whatever the size of the input, so reaching the cap means the sweep is stuck on that input, and it is reported rather than left running.
+The decomposition settles one singular value at a time through repeated sweeps. `maxIterations`, 100 by default, caps how many sweeps any one value gets. If another sweep would exceed the cap, the decomposition reports that it did not converge instead of continuing without a bound.
 
 #### Linear dependencies
 ```js

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ const {
   LuDecomposition,
   CholeskyDecomposition,
   EigenvalueDecomposition,
+  SingularValueDecomposition,
 } = require('ml-matrix');
 ```
 #### Inverse and Pseudo-inverse
@@ -285,6 +286,22 @@ var real = e.realEigenvalues;
 var imaginary = e.imaginaryEigenvalues;
 var vectors = e.eigenvectorMatrix;
 ```
+##### Singular Value Decomposition
+```js
+var A = new Matrix([
+  [2, 3, 5],
+  [4, 1, 6],
+  [1, 3, 0],
+]);
+
+var svd = new SingularValueDecomposition(A);
+var U = svd.leftSingularVectors;
+var s = svd.diagonal;
+var V = svd.rightSingularVectors;
+// U * diag(s) * V.transpose() gives A back
+```
+The decomposition settles one singular value at a time through repeated sweeps. `maxIterations`, 100 by default, caps how many sweeps any one value gets. A decomposition that converges takes a handful per value whatever the size of the input, so reaching the cap means the sweep is stuck on that input, and it is reported rather than left running.
+
 #### Linear dependencies
 ```js
 var A = new Matrix([

--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -1478,6 +1478,15 @@ export interface ISVDOptions {
    * @default `false`
    */
   autoTranspose?: boolean;
+
+  /**
+   * Ceiling on the number of sweeps spent settling any single singular value. Reaching it
+   * throws rather than letting the sweep run on. A decomposition that converges takes a
+   * handful of sweeps per value regardless of the size of the input, so the default leaves
+   * a wide margin. Raise it only after seeing the error.
+   * @default `100`
+   */
+  maxIterations?: number;
 }
 
 /**

--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -1480,10 +1480,8 @@ export interface ISVDOptions {
   autoTranspose?: boolean;
 
   /**
-   * Ceiling on the number of sweeps spent settling any single singular value. Reaching it
-   * throws rather than letting the sweep run on. A decomposition that converges takes a
-   * handful of sweeps per value regardless of the size of the input, so the default leaves
-   * a wide margin. Raise it only after seeing the error.
+   * Maximum number of sweeps spent settling any single singular value. If another sweep
+   * would exceed the limit, the decomposition throws instead of continuing without a bound.
    * @default `100`
    */
   maxIterations?: number;

--- a/src/__tests__/decompositions/svdMaxIterations.test.js
+++ b/src/__tests__/decompositions/svdMaxIterations.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+
+import { Matrix, SingularValueDecomposition } from '../..';
+
+const wellBehaved = new Matrix([
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 10],
+  [2, 9, 4],
+]);
+
+describe('SVD sweep ceiling', () => {
+  it('a decomposition that converges is untouched by the default', () => {
+    const svd = new SingularValueDecomposition(wellBehaved);
+    const product = svd.leftSingularVectors
+      .mmul(Matrix.diag(svd.diagonal))
+      .mmul(svd.rightSingularVectors.transpose());
+    for (let i = 0; i < wellBehaved.rows; i++) {
+      for (let j = 0; j < wellBehaved.columns; j++) {
+        expect(product.get(i, j)).toBeCloseTo(wellBehaved.get(i, j), 10);
+      }
+    }
+  });
+
+  it('a ceiling of one sweep is reported rather than passed over', () => {
+    expect(
+      () =>
+        new SingularValueDecomposition(Matrix.rand(40, 25), {
+          maxIterations: 1,
+        }),
+    ).toThrow(
+      /^SVD did not converge after 1 iterations on a single singular value$/,
+    );
+  });
+
+  it('the ceiling is counted per singular value, not over the whole run', () => {
+    // a handful of sweeps settles a value whatever the size of the input, so a
+    // larger matrix does not need a larger ceiling
+    expect(
+      () =>
+        new SingularValueDecomposition(Matrix.rand(200, 150), {
+          maxIterations: 20,
+        }),
+    ).not.toThrow();
+  });
+
+  it('a generous ceiling behaves like the default', () => {
+    const bounded = new SingularValueDecomposition(wellBehaved, {
+      maxIterations: 1000,
+    });
+    const plain = new SingularValueDecomposition(wellBehaved);
+    expect(bounded.diagonal).toStrictEqual(plain.diagonal);
+  });
+
+  it('rejects a ceiling that is not a positive integer', () => {
+    for (const value of [0, -1, 2.5, '10', null]) {
+      expect(
+        () =>
+          new SingularValueDecomposition(wellBehaved, {
+            maxIterations: value,
+          }),
+      ).toThrow(/^maxIterations must be a positive integer$/);
+    }
+  });
+});

--- a/src/__tests__/decompositions/svdMaxIterations.test.js
+++ b/src/__tests__/decompositions/svdMaxIterations.test.js
@@ -1,3 +1,4 @@
+import { XSadd } from 'ml-xsadd';
 import { describe, it, expect } from 'vitest';
 
 import { Matrix, SingularValueDecomposition } from '../..';
@@ -8,6 +9,10 @@ const wellBehaved = new Matrix([
   [7, 8, 10],
   [2, 9, 4],
 ]);
+
+function randomMatrix(rows, columns, seed) {
+  return Matrix.rand(rows, columns, { random: new XSadd(seed).random });
+}
 
 describe('SVD sweep ceiling', () => {
   it('a decomposition that converges is untouched by the default', () => {
@@ -25,20 +30,18 @@ describe('SVD sweep ceiling', () => {
   it('a ceiling of one sweep is reported rather than passed over', () => {
     expect(
       () =>
-        new SingularValueDecomposition(Matrix.rand(40, 25), {
+        new SingularValueDecomposition(randomMatrix(40, 25, 42), {
           maxIterations: 1,
         }),
     ).toThrow(
-      /^SVD did not converge after 1 iterations on a single singular value$/,
+      /^SVD did not converge after 1 iteration on a single singular value$/,
     );
   });
 
   it('the ceiling is counted per singular value, not over the whole run', () => {
-    // a handful of sweeps settles a value whatever the size of the input, so a
-    // larger matrix does not need a larger ceiling
     expect(
       () =>
-        new SingularValueDecomposition(Matrix.rand(200, 150), {
+        new SingularValueDecomposition(randomMatrix(200, 150, 43), {
           maxIterations: 20,
         }),
     ).not.toThrow();

--- a/src/dc/svd.js
+++ b/src/dc/svd.js
@@ -18,7 +18,12 @@ export default class SingularValueDecomposition {
       computeLeftSingularVectors = true,
       computeRightSingularVectors = true,
       autoTranspose = false,
+      maxIterations = 100,
     } = options;
+
+    if (!Number.isInteger(maxIterations) || maxIterations < 1) {
+      throw new RangeError('maxIterations must be a positive integer');
+    }
 
     let wantu = Boolean(computeLeftSingularVectors);
     let wantv = Boolean(computeRightSingularVectors);
@@ -365,6 +370,14 @@ export default class SingularValueDecomposition {
           }
           e[p - 2] = f;
           iter = iter + 1;
+          // iter counts the sweeps spent on the singular value currently being
+          // split off, and resets once that value settles. an input the sweep
+          // cannot settle would otherwise keep this loop going forever
+          if (iter > maxIterations) {
+            throw new Error(
+              `SVD did not converge after ${maxIterations} iterations on a single singular value`,
+            );
+          }
           break;
         }
         case 4: {

--- a/src/dc/svd.js
+++ b/src/dc/svd.js
@@ -307,6 +307,15 @@ export default class SingularValueDecomposition {
           break;
         }
         case 3: {
+          // iter resets when the current singular value settles. Refuse the
+          // next sweep once this value has consumed its full allowance.
+          if (iter >= maxIterations) {
+            const iterationWord =
+              maxIterations === 1 ? 'iteration' : 'iterations';
+            throw new Error(
+              `SVD did not converge after ${maxIterations} ${iterationWord} on a single singular value`,
+            );
+          }
           const scale = Math.max(
             Math.abs(s[p - 1]),
             Math.abs(s[p - 2]),
@@ -370,14 +379,6 @@ export default class SingularValueDecomposition {
           }
           e[p - 2] = f;
           iter = iter + 1;
-          // iter counts the sweeps spent on the singular value currently being
-          // split off, and resets once that value settles. an input the sweep
-          // cannot settle would otherwise keep this loop going forever
-          if (iter > maxIterations) {
-            throw new Error(
-              `SVD did not converge after ${maxIterations} iterations on a single singular value`,
-            );
-          }
           break;
         }
         case 4: {


### PR DESCRIPTION
Closes #70.

## Summary

The issue reports a dataset that hangs, with the observation that `p` never drops below 93. That `p` is the counter driving the sweep in the singular value decomposition:

```js
let iter = 0;
...
while (p > 0) {
  ...
  iter = iter + 1;
```

`iter` is raised on every sweep along with being reset once a singular value settles, yet nothing ever reads it. There is no ceiling anywhere in the loop, so an input the sweep cannot settle keeps it going with no way out. The caller gets no error, no result, and no thread back.

LAPACK bounds the same loop, `dbdsqr` allowing 6 sweeps per singular value before it reports failure.

## The ceiling

A `maxIterations` option, 100 by default, caps how many sweeps any one singular value gets. Passing it means the sweep is stuck, which is reported:

```
Error: SVD did not converge after 100 iterations on a single singular value
```

## Choosing the default

Measuring how many sweeps a decomposition that converges takes per singular value, across random matrices:

| ceiling | 40x25, out of 40 | 200x150, out of 10 |
| --- | --- | --- |
| 1 | 40 reported | 10 reported |
| 2 | 40 reported | 10 reported |
| 3 | 37 reported | 10 reported |
| 5 | none | none |
| 10 | none | none |
| 100 | none | none |

Four sweeps covers every case measured, and the figure does not grow with the size of the input, since the count is spent per singular value rather than over the whole run. A default of 100 therefore sits at roughly 25 times what a decomposition needs, wide enough that a converging input cannot reach it, while a stuck one stops in bounded time instead of running on.

## Compatibility

Every decomposition that converges today behaves exactly as before. The only inputs affected are the ones that never finish.
