### PR TITLE
Warn when the inner dimension of a matrix multiplication does not match

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ const modulo         = Matrix.mod(B, 2);   // modulo         = Matrix [[1, 1], [
 const maxMatrix      = Matrix.max(A, B);   // max            = Matrix [[3, 3], [2, 2], rows: 2, columns: 2]
 const minMatrix      = Matrix.min(A, B);   // max            = Matrix [[1, 1], [1, 1], rows: 2, columns: 2]
 ```
+`mmul` needs the number of columns of the left operand to equal the number of rows of the right one. A pair that does not line up is logged as a warning, the result of such a call being undefined: a taller right operand has its trailing rows dropped, a shorter one raises a `TypeError`.
+
 
 #### Inplace Operations
 ```js

--- a/matrix.d.ts
+++ b/matrix.d.ts
@@ -624,6 +624,9 @@ export abstract class AbstractMatrix {
 
   /**
    * Returns the matrix product between `this` and `other`.
+   * The number of columns of `this` has to equal the number of rows of `other`. A pair that
+   * does not line up is logged as a warning, the result of such a call being undefined:
+   * a taller `other` has its trailing rows dropped, a shorter one raises a `TypeError`.
    * @param other - Other matrix.
    */
   mmul(other: MaybeMatrix): Matrix;

--- a/src/__tests__/decompositions/svd.test.js
+++ b/src/__tests__/decompositions/svd.test.js
@@ -80,8 +80,16 @@ describe('Singular value decomposition', () => {
     });
 
     it('should be possible to get back original matrix', () => {
+      // the economy form reports more singular values than the singular vectors
+      // can carry here, so the diagonal is cut to the shape the two sides expect
       let actual = target.leftSingularVectors
-        .mmul(Matrix.diag(target.diagonal))
+        .mmul(
+          Matrix.diag(
+            target.diagonal,
+            target.leftSingularVectors.columns,
+            target.rightSingularVectors.columns,
+          ),
+        )
         .mmul(target.rightSingularVectors.transpose());
       expect(actual.to2DArray()).toBeDeepCloseTo(value.to2DArray(), 2);
     });

--- a/src/__tests__/matrix/mmulDimensions.test.js
+++ b/src/__tests__/matrix/mmulDimensions.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import { Matrix } from '../..';
 
@@ -85,74 +85,5 @@ describe('mmul warns about an inner dimension that does not match', () => {
       new Matrix(2, 0).mmul(new Matrix(0, 3));
     });
     expect(messages).toStrictEqual([]);
-  });
-
-  it('leaves the computed values alone', () => {
-    const messages = captureWarnings(() => {
-      const result = new Matrix([[1], [2], [3]]).mmul(
-        new Matrix([
-          [4, 5, 6],
-          [4, 5, 6],
-          [4, 5, 6],
-        ]),
-      );
-      expect(result.to2DArray()).toStrictEqual([
-        [4, 5, 6],
-        [8, 10, 12],
-        [12, 15, 18],
-      ]);
-    });
-    expect(messages).toHaveLength(1);
-  });
-});
-
-// the result of such a call stays undefined, these cases record what it is today
-// so that any move to refuse the call is a deliberate one
-describe('mmul on an inner dimension that does not match', () => {
-  beforeEach(() => {
-    vi.spyOn(console, 'warn').mockImplementation(() => {
-      // the warning itself is covered above, keep the reporter quiet here
-    });
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('drops the trailing rows of a taller right operand', () => {
-    const left = new Matrix([
-      [1, 2],
-      [3, 4],
-    ]);
-    const right = new Matrix([
-      [1, 0],
-      [0, 1],
-      [9, 9],
-    ]);
-    const truncated = right.subMatrix(0, 1, 0, 1);
-    expect(left.mmul(right).to2DArray()).toStrictEqual(
-      left.mmul(truncated).to2DArray(),
-    );
-  });
-
-  it('gives the shape the operands claim rather than the one used', () => {
-    const result = new Matrix([[1], [2], [3]]).mmul(
-      new Matrix([
-        [4, 5, 6],
-        [4, 5, 6],
-        [4, 5, 6],
-      ]),
-    );
-    expect(result.rows).toBe(3);
-    expect(result.columns).toBe(3);
-  });
-
-  it('raises a TypeError on a shorter right operand', () => {
-    expect(() =>
-      new Matrix([
-        [1, 2, 3],
-        [4, 5, 6],
-      ]).mmul(new Matrix([[1], [2]])),
-    ).toThrow(TypeError);
   });
 });

--- a/src/__tests__/matrix/mmulDimensions.test.js
+++ b/src/__tests__/matrix/mmulDimensions.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { Matrix } from '../..';
 
@@ -103,5 +103,56 @@ describe('mmul warns about an inner dimension that does not match', () => {
       ]);
     });
     expect(messages).toHaveLength(1);
+  });
+});
+
+// the result of such a call stays undefined, these cases record what it is today
+// so that any move to refuse the call is a deliberate one
+describe('mmul on an inner dimension that does not match', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      // the warning itself is covered above, keep the reporter quiet here
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('drops the trailing rows of a taller right operand', () => {
+    const left = new Matrix([
+      [1, 2],
+      [3, 4],
+    ]);
+    const right = new Matrix([
+      [1, 0],
+      [0, 1],
+      [9, 9],
+    ]);
+    const truncated = right.subMatrix(0, 1, 0, 1);
+    expect(left.mmul(right).to2DArray()).toStrictEqual(
+      left.mmul(truncated).to2DArray(),
+    );
+  });
+
+  it('gives the shape the operands claim rather than the one used', () => {
+    const result = new Matrix([[1], [2], [3]]).mmul(
+      new Matrix([
+        [4, 5, 6],
+        [4, 5, 6],
+        [4, 5, 6],
+      ]),
+    );
+    expect(result.rows).toBe(3);
+    expect(result.columns).toBe(3);
+  });
+
+  it('raises a TypeError on a shorter right operand', () => {
+    expect(() =>
+      new Matrix([
+        [1, 2, 3],
+        [4, 5, 6],
+      ]).mmul(new Matrix([[1], [2]])),
+    ).toThrow(TypeError);
   });
 });

--- a/src/__tests__/matrix/mmulDimensions.test.js
+++ b/src/__tests__/matrix/mmulDimensions.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { Matrix } from '../..';
+
+// https://github.com/mljs/matrix/issues/202
+describe('mmul warns about an inner dimension that does not match', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function captureWarnings(callback) {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {
+      // keep the reporter quiet
+    });
+    callback();
+    return warn.mock.calls.map((call) => call[0]);
+  }
+
+  it('names both shapes when the other matrix is taller', () => {
+    const messages = captureWarnings(() => {
+      new Matrix([[1], [2], [3]]).mmul(
+        new Matrix([
+          [4, 5, 6],
+          [4, 5, 6],
+          [4, 5, 6],
+        ]),
+      );
+    });
+    expect(messages).toStrictEqual([
+      'Multiplying 3 x 1 and 3 x 3 matrix: dimensions do not match.',
+    ]);
+  });
+
+  it('names both shapes when the other matrix is shorter', () => {
+    const messages = captureWarnings(() => {
+      try {
+        new Matrix([
+          [1, 2, 3],
+          [4, 5, 6],
+        ]).mmul(new Matrix([[1], [2]]));
+      } catch {
+        // the call goes on to fail, the warning is what is under test here
+      }
+    });
+    expect(messages).toStrictEqual([
+      'Multiplying 2 x 3 and 2 x 1 matrix: dimensions do not match.',
+    ]);
+  });
+
+  it('matches the wording the Strassen multiplication already uses', () => {
+    const left = new Matrix([[1], [2], [3]]);
+    const right = new Matrix([
+      [4, 5, 6],
+      [4, 5, 6],
+      [4, 5, 6],
+    ]);
+    const fromMmul = captureWarnings(() => left.mmul(right));
+    const fromStrassen = captureWarnings(() => left.mmulStrassen(right));
+    expect(fromMmul).toStrictEqual(fromStrassen);
+  });
+
+  it('stays quiet on a pair that lines up', () => {
+    const messages = captureWarnings(() => {
+      new Matrix([
+        [1, 2, 3],
+        [4, 5, 6],
+      ]).mmul(new Matrix([[1], [2], [3]]));
+    });
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('stays quiet on a square product', () => {
+    const messages = captureWarnings(() => {
+      const square = new Matrix([
+        [1, 2],
+        [3, 4],
+      ]);
+      square.mmul(square);
+    });
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('stays quiet when a degenerate pair still lines up', () => {
+    const messages = captureWarnings(() => {
+      new Matrix(2, 0).mmul(new Matrix(0, 3));
+    });
+    expect(messages).toStrictEqual([]);
+  });
+
+  it('leaves the computed values alone', () => {
+    const messages = captureWarnings(() => {
+      const result = new Matrix([[1], [2], [3]]).mmul(
+        new Matrix([
+          [4, 5, 6],
+          [4, 5, 6],
+          [4, 5, 6],
+        ]),
+      );
+      expect(result.to2DArray()).toStrictEqual([
+        [4, 5, 6],
+        [8, 10, 12],
+        [12, 15, 18],
+      ]);
+    });
+    expect(messages).toHaveLength(1);
+  });
+});

--- a/src/matrix.js
+++ b/src/matrix.js
@@ -878,6 +878,13 @@ export class AbstractMatrix {
     let n = this.columns;
     let p = other.columns;
 
+    if (n !== other.rows) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Multiplying ${m} x ${n} and ${other.rows} x ${p} matrix: dimensions do not match.`,
+      );
+    }
+
     let result = new Matrix(m, p);
 
     let Bcolj = new Float64Array(n);


### PR DESCRIPTION
Closes #202.

## Summary

`mmul` is the one shape sensitive operation in the library that neither checks its operands nor says anything about them.

```js
new Matrix([[1], [2], [3]]).mmul(new Matrix([[4, 5, 6], [4, 5, 6], [4, 5, 6]]));
// [[4, 5, 6], [8, 10, 12], [12, 15, 18]]
```

A 3x1 by 3x3 product has no meaning, and the caller gets a 3x3 matrix back with nothing said. The other direction, a right operand carrying fewer rows than the left has columns, ends in `TypeError: Cannot read properties of undefined`.

Everything around it behaves differently. `Matrix.add` throws `Matrices dimensions must be equal`, `transposeMultiply` throws on rows that do not agree, and `mmulStrassen`, sitting in the same file and doing the same job, already logs this exact warning.

#195 covered the same ground and was closed on the grounds that a check that throws is a breaking change, which #218 on this repository has not changed. This takes the step that breaks nothing: the call keeps working exactly as it does today, along with saying so.

```
Multiplying 3 x 1 and 3 x 3 matrix: dimensions do not match.
```

The wording is the one `mmulStrassen` already uses, so the two agree on the same input.

## What the warning turned up

Two places inside the project relied on the mismatch.

The wide matrix reconstruction under `less rows than columns, no autotranspose` multiplies `U(2x2)` by `diag(s)(3x3)` by `Vᵀ(4x4)`. It lands on the right answer only because the trailing rows get dropped. Cutting the diagonal to the shape the two sides expect, through `Matrix.diag(s, U.columns, V.columns)`, gives identical values to the last digit while the operands line up.

`SingularValueDecomposition.solve` does the same thing at `V.mmul(Ls)`, `V` holding one column per column of the input against one per singular value in `Ls`. That path already ends in a `TypeError` on a wide matrix regardless of this change, so it wants its own look rather than a correction folded in here. It is left untouched.

## Compatibility

No result changes and nothing new is thrown. The check reads two numbers already loaded on the line above it, so a product whose operands line up is untouched.
